### PR TITLE
DE2639 Routing

### DIFF
--- a/apache_site.conf
+++ b/apache_site.conf
@@ -34,6 +34,16 @@
         SSLCertificateFile /etc/ssl/wildcard_crossroads_net.crt
         SSLCertificateKeyFile /etc/ssl/wildcard_crossroads_net.key
         SSLCertificateChainFile /etc/ssl/wildcard_crossroads_net.DigiCertCA.crt
+
+        RewriteEngine On
+
+        # Don't rewrite files or directories
+        RewriteCond %{REQUEST_FILENAME} -f [OR]
+        RewriteCond %{REQUEST_FILENAME} -d
+        RewriteRule ^ - [L]
+
+        # Rewrite everything else to index.html to allow html5 state links
+        RewriteRule ^ index.html [L]
 </VirtualHost>
 
 <VirtualHost *:80>
@@ -71,5 +81,5 @@
 
         # Force SSL for initial request
         RewriteEngine On
-        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]        
+        RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 </VirtualHost>


### PR DESCRIPTION
This PR adds a rewrite rule via Apache's mod_rewrite module to proxy any request for non-physical files to index.html. Once merged and deployed to INT, this should resolve the direct routing issue identified by [DE2639](https://rally1.rallydev.com/#/66096127196d/detail/defect/87023235356).