### PR TITLE
Defect/de2711 no outline button group

### DIFF
--- a/src/app/ui-components/buttons/groups/groups.component.html
+++ b/src/app/ui-components/buttons/groups/groups.component.html
@@ -21,8 +21,10 @@
 
 <div class="crds-example">
   <div class="btn-group">
-    <button class="btn btn-option btn-no-outline">Option</button>
-    <button class="btn btn-option btn-no-outline">Option</button>
+    <button class="btn btn-option btn-no-outline active">Option 1</button>
+    <button class="btn btn-option btn-no-outline">Option 2</button>
+    <button class="btn btn-option btn-no-outline">Option 3</button>
+    <button class="btn btn-option btn-no-outline">Option 4</button>
   </div>
 </div>
 

--- a/src/app/ui-components/buttons/groups/groups.component.html
+++ b/src/app/ui-components/buttons/groups/groups.component.html
@@ -14,6 +14,19 @@
 </div>
 
 <div class="page-subheader">
+  <h3>Horizontal Button Group - No Outlines</h3>
+</div>
+
+<p>To add non-outlined buttons to your button group, replace the class <code>btn-outline</code> with the class <code>btn-no-outline</code> to each individual button.</p>
+
+<div class="crds-example">
+  <div class="btn-group">
+    <button class="btn btn-option btn-no-outline">Option</button>
+    <button class="btn btn-option btn-no-outline">Option</button>
+  </div>
+</div>
+
+<div class="page-subheader">
   <h3>Flexbox Button Group - Horizontal</h3>
 </div>
 

--- a/src/app/ui-components/buttons/styles/styles.component.html
+++ b/src/app/ui-components/buttons/styles/styles.component.html
@@ -17,20 +17,6 @@
 </div>
 
 <div class="page-subheader">
-  <h3>Non-Outlined Buttons</h3>
-</div>
-
-<p>To achieve a borderless button with a white background, add the class <code>btn-no-outline</code> to each button.</p>
-
-<div class="crds-example">
-  <a href="#" class="btn btn-no-outline btn-primary">Link</a>
-  <button class="btn btn-no-outline btn-info" type="submit">Button</button>
-  <input class="btn btn-no-outline btn-gray" type="button" value="Input">
-  <button class="btn btn-no-outline btn-option">Option</button>
-  <input class="btn btn-no-outline btn-default" type="submit" value="Submit">
-</div>
-
-<div class="page-subheader">
   <h3>Outlined Buttons</h3>
 </div>
 

--- a/src/app/ui-components/buttons/styles/styles.component.html
+++ b/src/app/ui-components/buttons/styles/styles.component.html
@@ -17,6 +17,20 @@
 </div>
 
 <div class="page-subheader">
+  <h3>Non-Outlined Buttons</h3>
+</div>
+
+<p>To achieve a borderless button with a white background, add the class <code>btn-no-outline</code> to each button.</p>
+
+<div class="crds-example">
+  <a href="#" class="btn btn-no-outline btn-primary">Link</a>
+  <button class="btn btn-no-outline btn-info" type="submit">Button</button>
+  <input class="btn btn-no-outline btn-gray" type="button" value="Input">
+  <button class="btn btn-no-outline btn-option">Option</button>
+  <input class="btn btn-no-outline btn-default" type="submit" value="Submit">
+</div>
+
+<div class="page-subheader">
   <h3>Outlined Buttons</h3>
 </div>
 


### PR DESCRIPTION
>In-line giving has a button group pattern that shows buttons without an outline, once selected, they have a background. That needs to be a pattern in the DDK.

I created a button group demonstrating buttons without outlines. This new `.btn-no-outline` class works in any button configuration (normal button groups or flexbox button groups).