### PR TITLE
DE2728 - Border width

### DIFF
--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -3,8 +3,8 @@ textarea {
   &.form-control {
     &.focus-example {
       background: $cr-white;
-      border: 2px solid $cr-cyan-light;
-      box-shadow: none;
+      border-color: $input-border-focus;
+      box-shadow: inset 0 0 0 1px $input-border-focus;
     }
   }
 }


### PR DESCRIPTION
Fix focus border style on example input field. Uses the same focus style as `crds-styles`

Corresponds to `crds-styles/defect/DE2728-border-width`