### PR TITLE
US6543 - Separate alert section

### DIFF
--- a/src/app/ui-components/forms/forms.component.html
+++ b/src/app/ui-components/forms/forms.component.html
@@ -16,9 +16,6 @@
           <li routerLinkActive="active" class="list-group-item">
             <a routerLink="/ui/forms/groups">Groups</a>
           </li>
-          <li routerLinkActive="active" class="list-group-item">
-            <a routerLink="/ui/forms/alerts">Alert Messages</a>
-          </li>
         </ul>
       </nav>
     </aside>

--- a/src/app/ui-components/typography/typefaces/typefaces.component.html
+++ b/src/app/ui-components/typography/typefaces/typefaces.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="alert alert-warning">
-  <p>The class selectors defined below require the inclusion of Crossroad's custom library of web-fonts. <a routerLink="/ui/typography/web-fonts">Click here</a> to learn more about including web-fonts in your project.</p>
+  <p>The class selectors defined below require the inclusion of Crossroad's custom library of web-fonts. <a routerLink="/ui/typography/web-fonts" class="alert-link">Click here</a> to learn more about including web-fonts in your project.</p>
 </div>
 
 <p>By default, all elements will inherit the base font-family <a href="https://typekit.com/fonts/acumin">Acumin Pro</a>.</p>


### PR DESCRIPTION
Remove dead link to alert section from forms and fix styling for link in warning-alert.

Corresponds with crds-styles `feature/US6543-separate-alert-section`