### PR TITLE
Feature/us6542 add links to typesetting

### DIFF
--- a/src/app/ui-components/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/typography/typesetting/typesetting.component.html
@@ -104,7 +104,7 @@
   <p>Applying a class of <code>.secondary</code> to an <code>a</code> tag created a link that signifies a minor priority/utility. These links are also found beside a button or button group to Cancel an action.</p>
 
   <div class="crds-example main">
-    <a href="#" class="text-right secondary">one church</a>
+    <p>Crossroads is <a href="#" class="secondary">one church</a> happening in multiple locations.</p>
   </div>
 </div>
 

--- a/src/app/ui-components/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/typography/typesetting/typesetting.component.html
@@ -108,6 +108,18 @@
   </div>
 </div>
 
+<div class="alert alert-info" role="alert">All link styles can be combined with other utility classes, i.e., <code>.pull-right</code> or <code>.font-size-small</code> to alter look or layout.</div>
+
+<div class="crds-example">
+  <div class="clearfix">
+    <a href="#" class="secondary font-size-small pull-right">Forgot password?</a>
+    <br>
+    <a href="#" class="secondary font-size-small pull-right">Need help?</a>
+  </div>
+  <hr>
+  <a href="#" class="font-size-small">Register an account</a>
+</div>
+
 <!-- // -->
 
 <div class="page-subheader">

--- a/src/app/ui-components/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/typography/typesetting/typesetting.component.html
@@ -92,6 +92,8 @@
   <hr>
 </div>
 
+<div class="alert alert-info" role="alert">All link styles can be combined with other utility classes, i.e., <code>.pull-right</code> or <code>.pull-left</code> to alter layout.</div>
+
 <div class="selector">
   <p>Standalone <code>a</code> tags are used for actions that don't warrant a button, yet are of next highest priority/utility.</p>
 

--- a/src/app/ui-components/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/typography/typesetting/typesetting.component.html
@@ -92,8 +92,6 @@
   <hr>
 </div>
 
-<div class="alert alert-info" role="alert">All link styles can be combined with other utility classes, i.e., <code>.pull-right</code> or <code>.pull-left</code> to alter layout.</div>
-
 <div class="selector">
   <p>Standalone <code>a</code> tags are used for actions that don't warrant a button, yet are of next highest priority/utility.</p>
 
@@ -106,7 +104,7 @@
   <p>Applying a class of <code>.secondary</code> to an <code>a</code> tag created a link that signifies a minor priority/utility. These links are also found beside a button or button group to Cancel an action.</p>
 
   <div class="crds-example main">
-    <p>Crossroads is <a href="#" class="secondary">one church</a> happening in multiple locations.</p>
+    <a href="#" class="text-right secondary">one church</a>
   </div>
 </div>
 

--- a/src/app/ui-components/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/typography/typesetting/typesetting.component.html
@@ -85,6 +85,29 @@
 <p class="body"><small>Crossroads is one church happening in multiple locations.</small></p></div>
 </div>
 
+<!-- Links -->
+
+<div class="page-subheader">
+  <h3>Links</h3>
+  <hr>
+</div>
+
+<div class="selector">
+  <p>Standalone <code>a</code> tags are used for actions that don't warrant a button, yet are of next highest priority/utility.</p>
+
+  <div class="crds-example main">
+    <p>Crossroads is <a href="#">one church</a> happening in multiple locations.</p>
+  </div>
+</div>
+
+<div class="selector">
+  <p>Applying a class of <code>.secondary</code> to an <code>a</code> tag created a link that signifies a minor priority/utility. These links are also found beside a button or button group to Cancel an action.</p>
+
+  <div class="crds-example main">
+    <p>Crossroads is <a href="#" class="secondary">one church</a> happening in multiple locations.</p>
+  </div>
+</div>
+
 <!-- // -->
 
 <div class="page-subheader">


### PR DESCRIPTION
> Add colors for links (primary, secondary, etc)
Include when to use what type of link

_Note: This story uses the class `font-size-small` defined in US6466._

Corresponds with `crds-styles/feature/US6542-add-links-to-typesetting`