### PR TITLE
DE2815 - Checkboxes and radio buttons busted

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,9 @@ export class AppComponent implements AfterViewChecked {
   constructor(private elementRef: ElementRef, private renderer: Renderer) {
     this.renderer.listen(this.elementRef.nativeElement, 'click', (event) => {
       if (event.target.closest('.crds-example')) {
-        return false;
+        if (event.target.nodeName === "A" || event.target.classList.contains("btn")) {
+          return false;
+        }
       }
     });
   }


### PR DESCRIPTION
Radio buttons and checkboxes weren't behaving correctly (wouldn't select/deselect options). Rewriting a click event function so it only effects buttons and links.

Corresponds with `crds-styles/development`