### PR TITLE
DE2897 - Input lg

### DIFF
--- a/src/app/ui-components/forms/form-groups/groups.component.html
+++ b/src/app/ui-components/forms/form-groups/groups.component.html
@@ -11,7 +11,7 @@
     <label for="customAmount" class="sr-only">Amount (in dollars)</label>
     <div class="input-group input-group-left">
       <span class="input-group-addon">$</span>
-      <input type="customAmount" name="customAmount" value="" placeholder="Enter Amount" class="form-control">
+      <input type="customAmount" name="customAmount" value="" placeholder="Enter Amount" class="form-control input-lg">
     </div>
   </div>
 </div>


### PR DESCRIPTION
> It looks like the way we've overwritten the default bootrap inputs causes "input-lg" class to not work.
The amount field should be larger (to match prod design) in embed once the above issue is resolved.

Corresponds with crdschurch/crds-styles#59
Corresponds with crdschurch/crds-embed#255