### PR TITLE
DE2895 - Invoke error states

### DIFF
--- a/src/app/ui-components/forms/form-states/form-states.component.html
+++ b/src/app/ui-components/forms/form-states/form-states.component.html
@@ -23,12 +23,12 @@
   <h3>Input Field &mdash; Valid</h3>
 </div>
 
-<p>A class of <code>ng-valid</code> can only be seen when the input field has the classes of <code>ng-dirty</code> and <code>ng-touched</code>, and the validation criteria is met.</p>
+<p>A valid input field is determined by the class <code>.ng-valid</code>. Validation is checked after a user has touched that field (indicated by the class <code>.ng-touched</code>).</p>
 
 <div class="crds-example">
   <div class="form-group">
     <label for="email" class="sr-only">Email</label>
-    <input type="email" name="email" value="" placeholder="Email" class="form-control ng-dirty ng-touched ng-valid" value="joe@dirt.com">
+    <input type="email" name="email" value="" placeholder="Email" class="form-control ng-touched ng-valid" value="joe@dirt.com">
   </div>
 </div>
 
@@ -36,23 +36,12 @@
   <h3>Input Field &mdash; Invalid</h3>
 </div>
 
-<p>There are two styles for invalid input states. When the user clicks submit without attempting to enter text in the input field, a class of <code>ng-touched</code> will be added to the input field.</p>
+<p>An invalid state on an input field is determined by the <code>.ng-invalid</code> class. Validation is checked after a user has touched that field (indicated by the class <code>.ng-touched</code>).</p>
 
 <div class="crds-example">
   <div class="form-group">
     <label for="email" class="sr-only">Email</label>
     <input type="email" name="email" value="" placeholder="Email" class="form-control ng-touched ng-invalid" value="larry@">
-  </div>
-</div>
-
-<br>
-
-<p>When a user has attempted to enter text in the input field, a class of <code>ng-dirty</code> is added to the input field. This style comes into play when the entered text doesn't meet the validation criteria.</p>
-
-<div class="crds-example">
-  <div class="form-group">
-    <label for="email" class="sr-only">Email</label>
-    <input type="email" name="email" value="" placeholder="Email" class="form-control ng-dirty ng-touched ng-invalid" value="larry@">
   </div>
 </div>
 


### PR DESCRIPTION
Addressing Brian's concerns on form field validation:
1. Implement valid/invalid `:focus` state, see Bootstrap [example](http://getbootstrap.com/css/#forms-control-validation)
2. Simplify invalid state
3. Validation should mimic embed in that it checks the input once a user clicks off the field

Corresponds with crdschurch/crds-styles#60