### PR TITLE
DE2886 - Icon Colors

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -71,7 +71,12 @@ module.exports = {
       {
         context: './node_modules/crds-styles/assets/stylesheets/svg/assets/',
         from: '*.svg',
-        to: 'assets',
+        to: 'assets'
+      },
+      {
+        context: './node_modules/crds-styles/assets/',
+        from: '*.svg',
+        to: 'assets'
       }
     ], { ignore: ['mock-data/*'] })
 

--- a/src/app/directives/icons/icons.service.ts
+++ b/src/app/directives/icons/icons.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+
+export class IconService {
+  
+  icons = [
+    'calendar',
+    'check-circle',
+    'chevron-left',
+    'chevron-right',
+    'circle-thin',
+    'contrast',
+    'facebook',
+    'github',
+    'twitter',
+    'instagram',
+    'usd',
+    'youtube'
+  ]
+
+}

--- a/src/app/ui-components/icons/colors/colors.component.html
+++ b/src/app/ui-components/icons/colors/colors.component.html
@@ -1,0 +1,70 @@
+<div class="page-header">
+  <h2>Resizing Icons</h2>
+</div>
+
+<p>
+  Add one of the following classes to resize an icon.
+</p>
+<ul class="list-inline">
+  <li>
+    <code>.icon-1</code>
+  </li>
+  <li>
+    <code>.icon-2</code>
+  </li>
+  <li>
+    <code>.icon-3</code>
+  </li>
+  <li>
+    <code>.icon-4</code>
+  </li>
+  <li>
+    <code>.icon-5</code>
+  </li>
+  <li>
+    <code>.icon-6</code>
+  </li>
+</ul>
+
+<div class="page-subheader">
+  <h3>Resizing Inline SVG Icons</h3>
+</div>
+
+<div class="crds-example">
+  <svg class="svg-github icon icon-1">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+
+  <svg class="svg-github icon icon-2">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+
+  <svg class="svg-github icon icon-3">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+
+  <svg class="svg-github icon icon-4">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+
+  <svg class="svg-github icon icon-5">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+
+  <svg class="svg-github icon icon-6">
+    <use xlink:href="/assets/sprite.css.svg#github"></use>
+  </svg>
+</div>
+
+<div class="page-subheader">
+  <h3>Resizing CSS SVG Icons</h3>
+</div>
+
+<div class="crds-example">
+  <i class="icon icon-1 svg-calendar"></i>
+  <i class="icon icon-2 svg-calendar"></i>
+  <i class="icon icon-3 svg-calendar"></i>
+  <i class="icon icon-4 svg-calendar"></i>
+  <i class="icon icon-5 svg-calendar"></i>
+  <i class="icon icon-6 svg-calendar"></i>
+</div>

--- a/src/app/ui-components/icons/colors/colors.component.html
+++ b/src/app/ui-components/icons/colors/colors.component.html
@@ -1,70 +1,55 @@
 <div class="page-header">
-  <h2>Resizing Icons</h2>
+  <h2>Icon Colors</h2>
 </div>
 
 <p>
-  Add one of the following classes to resize an icon.
+  Icons' <code>&lt;use&gt;</code> element will inherit the color of the closest
+  parent with a color applied.
 </p>
-<ul class="list-inline">
-  <li>
-    <code>.icon-1</code>
-  </li>
-  <li>
-    <code>.icon-2</code>
-  </li>
-  <li>
-    <code>.icon-3</code>
-  </li>
-  <li>
-    <code>.icon-4</code>
-  </li>
-  <li>
-    <code>.icon-5</code>
-  </li>
-  <li>
-    <code>.icon-6</code>
-  </li>
-</ul>
 
 <div class="page-subheader">
-  <h3>Resizing Inline SVG Icons</h3>
+  <h3>Applied to Icon</h3>
 </div>
 
+<p>
+  You can apply a color helper directly to the <code>&lt;svg&gt;</code> element.
+</p>
+
 <div class="crds-example">
-  <svg class="svg-github icon icon-1">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
-
-  <svg class="svg-github icon icon-2">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
-
-  <svg class="svg-github icon icon-3">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
-
-  <svg class="svg-github icon icon-4">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
-
-  <svg class="svg-github icon icon-5">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
-
-  <svg class="svg-github icon icon-6">
-    <use xlink:href="/assets/sprite.css.svg#github"></use>
-  </svg>
+<svg class="icon text-danger" viewBox="0 0 256 256">
+  <use height="256" width="256" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/icons.svg#calendar"></use>
+</svg>
 </div>
 
 <div class="page-subheader">
-  <h3>Resizing CSS SVG Icons</h3>
+  <h3>Applied to Parent</h3>
 </div>
 
+<p>
+  Here the color is applied to the parent element and the icon inherits it.
+</p>
+
 <div class="crds-example">
-  <i class="icon icon-1 svg-calendar"></i>
-  <i class="icon icon-2 svg-calendar"></i>
-  <i class="icon icon-3 svg-calendar"></i>
-  <i class="icon icon-4 svg-calendar"></i>
-  <i class="icon icon-5 svg-calendar"></i>
-  <i class="icon icon-6 svg-calendar"></i>
+<div class="text-primary">
+  <svg class="icon" viewBox="0 0 256 256">
+    <use height="256" width="256" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/icons.svg#calendar"></use>
+  </svg>
+</div>
+</div>
+
+<div class="page-subheader">
+  <h3>Background Colors</h3>
+</div>
+
+<p>
+  Notice that if the component in which the icon is placed has an color applied,
+  the icon will also inherit that color.
+</p>
+
+<div class="crds-example">
+<div class="alert alert-info">
+  <svg class="icon" viewBox="0 0 256 256">
+    <use height="256" width="256" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/icons.svg#calendar"></use>
+  </svg>
+</div>
 </div>

--- a/src/app/ui-components/icons/colors/colors.component.spec.ts
+++ b/src/app/ui-components/icons/colors/colors.component.spec.ts
@@ -1,0 +1,8 @@
+import { IconColorsComponent } from './colors.component';
+
+describe('Component: IconResize', () => {
+  it('should create an instance', () => {
+    let component = new IconColorsComponent();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui-components/icons/colors/colors.component.ts
+++ b/src/app/ui-components/icons/colors/colors.component.ts
@@ -1,0 +1,6 @@
+import { Component } from '@angular/core';
+
+@Component({
+  templateUrl: './colors.component.html'
+})
+export class IconColorsComponent {}

--- a/src/app/ui-components/icons/directory/directory.component.html
+++ b/src/app/ui-components/icons/directory/directory.component.html
@@ -10,25 +10,10 @@
 </p>
 
 <ul class="list-unstyled push-top soft-top icon-directory-list">
-  <li>
-    <i class="icon icon-1 svg-calendar"></i> <span class="soft-half-left">svg-calendar</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-check-circle"></i> <span class="soft-half-left">svg-check-circle</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-chevron-left"></i> <span class="soft-half-left">svg-chevron-left</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-chevron-right"></i> <span class="soft-half-left">svg-chevron-right</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-circle-thin"></i> <span class="soft-half-left">svg-circle-thin</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-github"></i> <span class="soft-half-left">svg-github</span>
-  </li>
-  <li>
-    <i class="icon icon-1 svg-usd"></i> <span class="soft-half-left">svg-usd</span>
+  <li *ngFor="let icon of icons">
+    <svg class="icon icon-1" viewBox="0 0 256 256">
+      <use attr.xlink:href="/assets/icons.svg#{{icon}}" height="256" width="256"></use>
+    </svg>
+    <span class="soft-half-left">{{icon}}</span>
   </li>
 </ul>

--- a/src/app/ui-components/icons/directory/directory.component.ts
+++ b/src/app/ui-components/icons/directory/directory.component.ts
@@ -1,6 +1,18 @@
 import { Component } from '@angular/core';
+import { IconService } from '../../../directives/icons/icons.service'
 
 @Component({
-  templateUrl: './directory.component.html'
+  templateUrl: './directory.component.html',
+  providers: [IconService]
 })
-export class IconDirectoryComponent {}
+export class IconDirectoryComponent {
+
+  icons = [];
+
+  constructor(private _iconService: IconService) {}
+
+  ngOnInit() {
+    this.icons = this._iconService.icons;
+  }
+
+}

--- a/src/app/ui-components/icons/icons.component.html
+++ b/src/app/ui-components/icons/icons.component.html
@@ -21,6 +21,9 @@
           <li routerLinkActive="active" class="list-group-item">
             <a routerLink="/ui/icons/resize-svg">Resizing Icons</a>
           </li>
+          <li routerLinkActive="active" class="list-group-item">
+            <a routerLink="/ui/icons/colors">Icon Colors</a>
+          </li>
         </ul>
       </nav>
     </aside>

--- a/src/app/ui-components/icons/inline-svg/inline-svg.component.html
+++ b/src/app/ui-components/icons/inline-svg/inline-svg.component.html
@@ -6,60 +6,12 @@
 
 <div class="row">
 
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-calendar icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#calendar"></use>
+  <div class="col-sm-6" *ngFor="let icon of icons">
+    <div class="crds-example">
+<svg class="icon icon-1" viewBox="0 0 256 256">
+  <use attr.xlink:href="/assets/icons.svg#{{icon}}" height="256" width="256"></use>
 </svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-check-circle icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#check-circle"></use>
-</svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-chevron-left icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#chevron-left"></use>
-</svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-chevron-right icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#chevron-right"></use>
-</svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-circle-thin icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#circle-thin"></use>
-</svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-github icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#github"></use>
-</svg>
-</div>
-</div>
-
-<div class="col-sm-6">
-<div class="crds-example">
-<svg class="svg-usd icon icon-1">
-<use xlink:href="/assets/sprite.css.svg#usd"></use>
-</svg>
-</div>
-</div>
+    </div>
+  </div>
 
 </div>

--- a/src/app/ui-components/icons/inline-svg/inline-svg.component.ts
+++ b/src/app/ui-components/icons/inline-svg/inline-svg.component.ts
@@ -1,23 +1,19 @@
 import { Component } from '@angular/core';
+import { IconService } from '../../../directives/icons/icons.service'
 
 @Component({
-  templateUrl: './inline-svg.component.html'
+  templateUrl: './inline-svg.component.html',
+  providers: [IconService]
 })
+
 export class IconInlineComponent {
 
-  icons = [
-    'calendar',
-    'check-circle',
-    'chevron-left',
-    'chevron-right',
-    'circle-thin',
-    'contrast',
-    'facebook',
-    'github',
-    'twitter',
-    'instagram',
-    'usd',
-    'youtube'
-  ]
+  icons = [];
+
+  constructor(private _iconService: IconService) {}
+
+  ngOnInit() {
+    this.icons = this._iconService.icons;
+  }
 
 }

--- a/src/app/ui-components/icons/inline-svg/inline-svg.component.ts
+++ b/src/app/ui-components/icons/inline-svg/inline-svg.component.ts
@@ -3,4 +3,21 @@ import { Component } from '@angular/core';
 @Component({
   templateUrl: './inline-svg.component.html'
 })
-export class IconInlineComponent {}
+export class IconInlineComponent {
+
+  icons = [
+    'calendar',
+    'check-circle',
+    'chevron-left',
+    'chevron-right',
+    'circle-thin',
+    'contrast',
+    'facebook',
+    'github',
+    'twitter',
+    'instagram',
+    'usd',
+    'youtube'
+  ]
+
+}

--- a/src/app/ui-components/ui-components.module.ts
+++ b/src/app/ui-components/ui-components.module.ts
@@ -60,6 +60,7 @@ import { IconDirectoryComponent } from './icons/directory/directory.component';
 import { IconInlineComponent } from './icons/inline-svg/inline-svg.component';
 import { IconCssComponent } from './icons/css-svg/css-svg.component';
 import { IconResizeComponent } from './icons/resize-svg/resize-svg.component';
+import { IconColorsComponent } from './icons/colors/colors.component';
 
 /* tables */
 import { TablesComponent } from './tables/tables.component';
@@ -135,6 +136,7 @@ import { SignInComponent } from './sign-in/sign-in.component';
     IconInlineComponent,
     IconCssComponent,
     IconResizeComponent,
+    IconColorsComponent,
 
     /* tables */
     TablesComponent,

--- a/src/app/ui-components/ui-routing.module.ts
+++ b/src/app/ui-components/ui-routing.module.ts
@@ -44,6 +44,7 @@ import { IconDirectoryComponent } from './icons/directory/directory.component';
 import { IconInlineComponent } from './icons/inline-svg/inline-svg.component';
 import { IconCssComponent } from './icons/css-svg/css-svg.component';
 import { IconResizeComponent } from './icons/resize-svg/resize-svg.component';
+import { IconColorsComponent } from './icons/colors/colors.component';
 
 /* tables */
 import { TablesComponent } from './tables/tables.component';
@@ -141,6 +142,10 @@ const uiRoutes: Routes = [
           {
             path: 'resize-svg',
             component: IconResizeComponent
+          },
+          {
+            path: 'colors',
+            component: IconColorsComponent
           }
         ]
       },


### PR DESCRIPTION
This adds the documentation for demonstrating how icons inherit colors.

This won't pass until #70 is merged (I didn't feel like cherry-picking every commit that solved the problem). Also note this already cherry-picked a few commits from #70.

And while it _should_ be coupled with a styles change, crdschurch/crds-styles#64 took care of this—that's the style change that will enable this example to work properly.