### PR TITLE
Defect/de2897 input lg

### DIFF
--- a/src/app/ui-components/forms/form-groups/groups.component.html
+++ b/src/app/ui-components/forms/form-groups/groups.component.html
@@ -7,7 +7,7 @@
 </div>
 
 <div class="crds-example">
-  <div class="form-group form-group-lg">
+  <div class="form-group">
     <label for="customAmount" class="sr-only">Amount (in dollars)</label>
     <div class="input-group input-group-left">
       <span class="input-group-addon">

--- a/src/app/ui-components/forms/form-groups/groups.component.html
+++ b/src/app/ui-components/forms/form-groups/groups.component.html
@@ -7,11 +7,13 @@
 </div>
 
 <div class="crds-example">
-  <div class="form-group">
+  <div class="form-group form-group-lg">
     <label for="customAmount" class="sr-only">Amount (in dollars)</label>
     <div class="input-group input-group-left">
-      <span class="input-group-addon">$</span>
-      <input type="customAmount" name="customAmount" value="" placeholder="Enter Amount" class="form-control input-lg">
+      <span class="input-group-addon">
+        <i class="icon svg-usd"></i>
+      </span>
+      <input type="customAmount" name="customAmount" value="" placeholder="Enter Amount" class="form-control">
     </div>
   </div>
 </div>


### PR DESCRIPTION
Refactored form field styles to use Bootstrap input-height helper classes (`input-lg`, `input-sm`, `form-group-lg`, `form-group-sm`).

Adjusted markup to match embed.

Corresponds with:
crdschurch/crds-embed#261
crdschurch/crds-styles#66