### PR TITLE
DE2988 - Finder component styling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "3.4.7",
     "angular2-fontawesome": "^0.8.0",
     "core-js": "^2.4.1",
-    "crds-styles": "0.2.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "font-awesome": "^4.7.0",
     "ng2-bootstrap": "~1.3.2",
     "prismjs": "^1.6.0",

--- a/src/app/ui-components/forms/form-groups/groups.component.html
+++ b/src/app/ui-components/forms/form-groups/groups.component.html
@@ -9,7 +9,7 @@
 <div class="crds-example">
   <div class="form-group">
     <label for="customAmount" class="sr-only">Amount (in dollars)</label>
-    <div class="input-group input-group-left">
+    <div class="input-group input-group-block input-group-left">
       <span class="input-group-addon">
         <svg class="icon" viewBox="0 0 256 256">
           <use xlink:href="/assets/svgs/icons.svg#usd"></use>
@@ -137,7 +137,7 @@
               action="/">
           <div class="form-group">
             <label class="sr-only" for="custom-input">Custom Input</label>
-            <div class="input-group input-group-left">
+            <div class="input-group input-group-block input-group-left">
               <span class="input-group-addon">$</span>
               <input type="text"
                     class="form-control"
@@ -190,7 +190,7 @@
       &lt;form class="custom-input-field" action="/">
         &lt;div class="form-group">
           &lt;label class="sr-only" for="custom-input">...&lt;/label>
-          &lt;div class="input-group">
+          &lt;div class="input-group input-group-block input-group-left">
             &lt;span class="input-group-addon">$&lt;/span>
             &lt;input type="text"
                   class="form-control"


### PR DESCRIPTION
Finder styling issue move buttons and elements off screen

Map View
Searchbar reflows
Getting started and my Pin buttons cause scroll bars for screen, Also move offscreen on mobile when rotating screen

I updated the custom input fields (on form-groups)

Corresponds with defect/DE2988-finder-component-styling-issues of `crds-styles`, `crds-styleguide`, `crds-finder`, `crds-embed`