### PR TITLE
DE3028 - Search icon missing in Safari/iOS

### DIFF
--- a/src/app/ui-components/icons/colors/colors.component.html
+++ b/src/app/ui-components/icons/colors/colors.component.html
@@ -23,7 +23,7 @@
 <figure class="highlight">
   <pre class="language-markup">
 &lt;svg class=&quot;icon text-primary&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;</pre>
 </figure>
 
@@ -46,7 +46,7 @@
   <pre class="language-markup">
 &lt;div class=&quot;text-secondary&quot;&gt;
   &lt;svg class=&quot;icon&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-    &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
+    &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
   &lt;&#x2F;svg&gt;
 &lt;&#x2F;div&gt;</pre>
 </figure>
@@ -71,7 +71,7 @@
   <pre class="language-markup">
 &lt;div class=&quot;alert alert-info&quot;&gt;
   &lt;svg class=&quot;icon&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-    &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
+    &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#calendar&quot;&gt;&lt;&#x2F;use&gt;
   &lt;&#x2F;svg&gt;
 &lt;&#x2F;div&gt;</pre>
 </figure>

--- a/src/app/ui-components/icons/inline-svg/inline-svg.component.html
+++ b/src/app/ui-components/icons/inline-svg/inline-svg.component.html
@@ -2,12 +2,14 @@
   <h2>Icon Usage</h2>
 </div>
 
-<p>SVG icons use the combination of <code>&lt;svg&gt;</code> and 
+<p>SVG icons use the combination of <code>&lt;svg&gt;</code> and
 <code>&lt;use&gt;</code> elements. The icon is dictated by the name after the
 hash in the <code>&lt;use&gt;</code> element's <code>href</code>. You can
 view the options in the <a routerLink="/ui/icons/directory">icon directory</a>.</p>
 
 <p>It's imperative that you include the <code>viewBox</code> attribute as shown below.</p>
+
+<div class="alert alert-info" role="alert">Prefixing the <code>href</code> attribute with <code>xlink:</code> is required for SVG images to display in Safari and iOS devices.</div>
 
 <div class="row">
 
@@ -20,7 +22,7 @@ view the options in the <a routerLink="/ui/icons/directory">icon directory</a>.<
     <figure class="highlight">
       <pre class="language-markup">
 &lt;svg class=&quot;icon&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#{{icon}}&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#{{icon}}&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;</pre>
     </figure>
   </div>

--- a/src/app/ui-components/icons/resize-svg/resize-svg.component.html
+++ b/src/app/ui-components/icons/resize-svg/resize-svg.component.html
@@ -54,27 +54,27 @@
 <figure class="highlight">
   <pre class="language-markup">
 &lt;svg class=&quot;icon icon-1&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
 
 &lt;svg class=&quot;icon icon-2&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
 
 &lt;svg class=&quot;icon icon-3&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
 
 &lt;svg class=&quot;icon icon-4&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
 
 &lt;svg class=&quot;icon icon-5&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
 
 &lt;svg class=&quot;icon icon-6&quot; viewBox=&quot;0 0 256 256&quot;&gt;
-  &lt;use href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
+  &lt;use xlink:href=&quot;&#x2F;assets&#x2F;svgs&#x2F;icons.svg#github&quot;&gt;&lt;&#x2F;use&gt;
 &lt;&#x2F;svg&gt;
   </pre>
 </figure>


### PR DESCRIPTION
I updated the example code blocks for SVGs to include the `xlink:` prefix. Also added an info box explaining why this is important for Safari/iOS

Corresponds with crds-styles/development and crdschurch/crds-connect#105

----------
the magnifying glass icon in the search submit button does not show in safari on ios and mac 