### PR TITLE
Feature/us7754 css refactor searchbar

### DIFF
--- a/src/app/ui-components/forms/form-groups/groups.component.html
+++ b/src/app/ui-components/forms/form-groups/groups.component.html
@@ -21,32 +21,6 @@
 </div>
 
 <div class="page-subheader">
-  <h3>Input Button</h3>
-</div>
-
-<div class="crds-example">
-  <div class="input-group">
-    <input type="text" class="form-control" placeholder="First Name">
-    <span class="input-group-btn">
-      <button type="submit" class="btn btn-secondary">
-        Submit
-      </button>
-    </span>
-  </div>
-  <hr>
-  <div class="input-group">
-    <input type="text" class="form-control" placeholder="Search">
-    <span class="input-group-btn">
-      <button type="submit" class="btn btn-secondary">
-        <svg class="icon icon-1" viewBox="0 0 256 256">
-          <use xlink:href="/assets/svgs/icons.svg#search"></use>
-        </svg>
-      </button>
-    </span>
-  </div>
-</div>
-
-<div class="page-subheader">
   <h3>2-Column Input Row</h3>
 </div>
 

--- a/src/app/ui-components/forms/search/search.component.html
+++ b/src/app/ui-components/forms/search/search.component.html
@@ -2,13 +2,10 @@
   <h2>Search Field</h2>
 </div>
 
-<p>
-  The search field uses input button groups. See
-  <a routerLink="/ui/forms/groups">the groups docs</a> for more information.
-</p>
+<p>The search field is built using Bootstrap's <a href="http://getbootstrap.com/components/#input-groups-buttons" target="_blank">Button Addons</a> component. By adding the class of <code>searchbar</code> to the <code>input-group</code>, you remove the form field validation styles that other input fields have.</p>
 
 <div class="crds-example">
-  <div class="input-group">
+  <div class="input-group searchbar">
     <input type="text" class="form-control" placeholder="Search ...">
     <span class="input-group-btn">
       <button type="submit" class="btn btn-secondary">


### PR DESCRIPTION
Remove documentation/example code for input with button group (already exists in Bootstrap's documentation) and update usage info on the search field section.

Corresponds with crdschurch/crds-styles#90 and crdschurch/crds-connect#200

----------
Move the styles for the search bar/input w/button styles from crds-connect to crds-styles. 
Clean up this input treatment to rely on Bootstrap's implementation more.
Add documentation on DDK for the special validation rules surrounding the search bar.


Part of a larger task to clean up connect.scss, clear out excess not in use and/or covered within crds-styles