### PR TITLE
Feature/us6924 add media objects

### DIFF
--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -149,6 +149,7 @@
                 <ul class="push-bottom hard-sides">
                   <li><a routerLink="/ui/sign-in" routerLinkActive="active">Sign In</a></li>
                   <li><a routerLink="/ui/avatar-groups" routerLinkActive="active">Avatar Groups</a></li>
+                  <li><a routerLink="/ui/media-objects" routerLinkActive="active">Media Objects</a></li>
                 </ul>
               </div>
             </div></div></div>

--- a/src/app/ui-components/media-objects/media-objects.component.html
+++ b/src/app/ui-components/media-objects/media-objects.component.html
@@ -6,8 +6,66 @@
 
 <div class="container">
   <div class="col-md-offset-3">
+    <div class="page-header">
+      <h2>Media Objects</h2>
+    </div>
 
-    <!-- Media object code goes here. -->
+    <p>Media objects are a commonly used UI component that feature a left- or right-aligned image alongside a block of text.</p>
 
+    <div class="page-subheader">
+      <h3>Default Media Object</h3>
+    </div>
+
+    <p>By default, the <code>.media-label</code> is in-line with the heading text.</p>
+
+    <ddk-example>
+      <div class="media">
+        <div class="media-img-wrapper">
+          <div class="media-object-default img-circle media-object img-size-5">
+          </div>
+        </div>
+
+        <div class="media-body">
+          <h3 class="media-heading">Jane Doe
+            <span class="media-label">
+              <span class="label label-default">LABEL</span>
+            </span>
+          </h3>
+
+          <p class="media-meta">1.0 MI</p>
+
+          <span>1234 Main St.<br>
+          City, ST 56789</span>
+        </div>
+      </div>
+    </ddk-example>
+
+    <div class="page-subheader">
+      <h3>Media Header Alignment</h3>
+    </div>
+
+    <p>A modifier class of <code>.media-heading-stacked</code> can be added to the <code>.media-heading</code> element. This allows the <code>.media-label</code> to stack above (or below) the header text.</p>
+
+    <ddk-example>
+      <div class="media">
+        <div class="media-img-wrapper">
+          <div class="media-object-default img-circle media-object img-size-5">
+          </div>
+        </div>
+
+        <div class="media-body">
+          <h3 class="media-heading media-heading-stacked">
+            <span class="media-label">
+              <span class="label label-default">LABEL</span>
+            </span> Jane Doe
+          </h3>
+
+          <p class="media-meta">1.0 MI</p>
+
+          <span>1234 Main St.<br>
+          City, ST 56789</span>
+        </div>
+      </div>
+    </ddk-example>
   </div>
 </div>

--- a/src/app/ui-components/media-objects/media-objects.component.html
+++ b/src/app/ui-components/media-objects/media-objects.component.html
@@ -1,0 +1,13 @@
+<div class="jumbotron">
+  <div class="container">
+    <crds-content-block id="UIMediaObjectsHeader"></crds-content-block>
+  </div>
+</div>
+
+<div class="container">
+  <div class="col-md-offset-3">
+
+    <!-- Media object code goes here. -->
+
+  </div>
+</div>

--- a/src/app/ui-components/media-objects/media-objects.component.spec.ts
+++ b/src/app/ui-components/media-objects/media-objects.component.spec.ts
@@ -1,0 +1,10 @@
+import { TestBed } from '@angular/core/testing';
+import { ElementRef, Renderer } from '@angular/core';
+import { MediaObjectsComponent } from './media-objects.component';
+
+describe('Component: MediaObjects', () => {
+  it('should create an instance', () => {
+    let component = new MediaObjectsComponent();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui-components/media-objects/media-objects.component.ts
+++ b/src/app/ui-components/media-objects/media-objects.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  templateUrl: './media-objects.component.html'
+})
+
+export class MediaObjectsComponent {
+}

--- a/src/app/ui-components/ui-components.module.ts
+++ b/src/app/ui-components/ui-components.module.ts
@@ -91,6 +91,9 @@ import { SignInComponent } from './sign-in/sign-in.component';
 /* avatar groups */
 import { AvatarGroupsComponent } from './avatar-groups/avatar-groups.component';
 
+/* media objects */
+import { MediaObjectsComponent } from './media-objects/media-objects.component';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -186,7 +189,10 @@ import { AvatarGroupsComponent } from './avatar-groups/avatar-groups.component';
     SignInComponent,
 
     /* avatar groups */
-    AvatarGroupsComponent
+    AvatarGroupsComponent,
+
+    /* media objects */
+    MediaObjectsComponent
   ]
 })
 export class UiComponentsModule { }

--- a/src/app/ui-components/ui-routing.module.ts
+++ b/src/app/ui-components/ui-routing.module.ts
@@ -72,6 +72,9 @@ import { SignInComponent } from './sign-in/sign-in.component';
 /* avatar groups */
 import { AvatarGroupsComponent } from './avatar-groups/avatar-groups.component';
 
+/* media objects */
+import { MediaObjectsComponent } from './media-objects/media-objects.component';
+
 const uiRoutes: Routes = [
   {
     path: 'ui',
@@ -309,6 +312,10 @@ const uiRoutes: Routes = [
       {
         path: 'avatar-groups',
         component: AvatarGroupsComponent
+      },
+      {
+        path: 'media-objects',
+        component: MediaObjectsComponent
       },
     ]
   }


### PR DESCRIPTION
Add code examples/use info on media objects to DDK. Pulling in example code from /connect. This section will probably grow to include different permutations.

Corresponds with crds-styles/development

---

Update DDK with new items from list view on Connect including:
- Add card/media object for list item
- Add labels (to be completed in another story)