### PR TITLE
DE3384 - Link to Page Top

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,16 @@
-import { Component, ViewEncapsulation, ElementRef, Renderer } from '@angular/core';
+import { Component, ViewEncapsulation, ElementRef, Renderer, OnInit } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer) {
+  constructor(private elementRef: ElementRef,
+              private renderer: Renderer,
+              private router: Router) {
     this.renderer.listen(this.elementRef.nativeElement, 'click', (event) => {
       if (event.target.closest('.crds-example')) {
         if (event.target.nodeName === 'A' || event.target.classList.contains('btn')) {
@@ -16,4 +19,28 @@ export class AppComponent {
       }
     });
   }
+
+  public ngOnInit() {
+    this.router.events.subscribe((evt) => {
+      if (!(evt instanceof NavigationEnd)) {
+        return;
+      }
+
+      /**
+       * This is an example of how we could track history if we want to don't
+       * want to scroll to the top of the page when going back to the previous
+       * page. It requires having a `routeHistory` array attribute on the class.
+       *
+       * this.routeHistory.push(evt.urlAfterRedirects);
+       * if (this.routeHistory.length > 3) {
+       *   this.routeHistory.splice(0, this.routeHistory.length - 3);
+       * }
+       * if (!this.routeHistory[2] || this.routeHistory[2] !== this.routeHistory[0]) {}
+       */
+
+      // Scroll to the top of the page when on navigation change.
+      window.scrollTo(0, 0);
+    });
+  }
+
 }


### PR DESCRIPTION
Scroll to the top of the page after navigating to a new page.

---

when you had made this change
" in the fourt bullet (shown below) link the words "Responsive Web Design" to https://design-int.crossroads.net/designers/getting-started/responsive-web-design"

the link is working, but i would expect it to be at the top of the Responsive Web Design page, currently it goes somewhere at the bottom of the page.

---

No corresponding pull requests.