### PR TITLE
DE3546 - Example Blocks

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -89,17 +89,16 @@ module.exports = {
 
         let hash = stats.hash,
             examples = glob.sync(
-              `${stats.compilation.compiler.outputPath}/examples/**/*.html`
-            ),
-            linkTag = `<link rel="stylesheet" href="/app.${hash}.css" />`;
+              `${stats.compilation.compiler.outputPath}/examples/**/index.html`
+            );
 
         // Loop through & edit each example...
         for (let example of examples) {
           fs.readFile(example, 'utf8', function (err, data) {
             if (err) return console.log(err);
 
-            if (data.includes('[import_styles]')) {
-              let newContent = data.replace(/\[import_styles\]/g, linkTag);
+            if (data.includes('/app.css')) {
+              let newContent = data.replace(/\/app\.css/g, `/app.${hash}.css"`);
               fs.writeFile(example, newContent, 'utf8', function (err) {
                 if (err) return console.log(err);
               });

--- a/src/examples/datepicker/index.html
+++ b/src/examples/datepicker/index.html
@@ -4,7 +4,7 @@
     <base href="." />
     <title>ng2-bootstrap datepicker</title>
 
-    [import_styles]
+    <link rel="stylesheet" href="/app.css" />
 
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>

--- a/src/examples/datepicker/index.html
+++ b/src/examples/datepicker/index.html
@@ -2,8 +2,10 @@
 <html>
   <head>
     <base href="." />
-    <title>angular2 playground</title>
-    <link rel="stylesheet" href="/app.css" />
+    <title>ng2-bootstrap datepicker</title>
+
+    [import_styles]
+
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
     <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
@@ -13,7 +15,7 @@
     System.import('app')
       .catch(console.error.bind(console));
   </script>
-  <script src=https://use.typekit.net/ccb3vpa.js></script>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   </head>
 

--- a/src/examples/map/index.html
+++ b/src/examples/map/index.html
@@ -4,7 +4,7 @@
     <base href="." />
     <title>angular2-google-maps</title>
 
-    [import_styles]
+    <link rel="stylesheet" href="/app.css" />
 
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>

--- a/src/examples/map/index.html
+++ b/src/examples/map/index.html
@@ -3,6 +3,9 @@
   <head>
     <base href="." />
     <title>angular2-google-maps</title>
+
+    [import_styles]
+
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
     <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
@@ -12,7 +15,7 @@
     System.import('app')
       .catch(console.error.bind(console));
   </script>
-  <script src=https://use.typekit.net/ccb3vpa.js></script>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   </head>
 

--- a/src/examples/toastr/index.html
+++ b/src/examples/toastr/index.html
@@ -4,7 +4,7 @@
     <base href="." />
     <title>ngx-toastr</title>
 
-    [import_styles]
+    <link rel="stylesheet" href="/app.css" />
 
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>

--- a/src/examples/toastr/index.html
+++ b/src/examples/toastr/index.html
@@ -4,8 +4,7 @@
     <base href="." />
     <title>ngx-toastr</title>
 
-    <!-- REQUIRED: is what brings in the crds-styles package. -->
-    <link rel="stylesheet" href="/app.css" />
+    [import_styles]
 
     <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
     <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
@@ -16,7 +15,7 @@
     System.import('app')
       .catch(console.error.bind(console));
   </script>
-  <script src=https://use.typekit.net/ccb3vpa.js></script>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   </head>
 


### PR DESCRIPTION
Use simple string replacement solution for injecting crds-styles into example blocks.

Previously I was hitting an error during a production build because the DOMParser did not like the attributes being used on some of the elements within these examples. This will continue to be an issue as example apps get more complicated.

This solution isn't awesome. It assumes an `index.html` file that has a reference to `/app.css`, and anywhere it finds that reference, it replaces it. This would ideally be more flexible down the road, but for now we are out to find a way to get these examples working in int.