### PR TITLE
US8558 - Homepage countdown bar

### DIFF
--- a/src/app/ui-components/countdown/countdown.component.html
+++ b/src/app/ui-components/countdown/countdown.component.html
@@ -9,7 +9,7 @@
 
 
     <ddk-example>
-<div class="countdown">
+<div class="container-fluid countdown">
   <span class="countdown-header">Join the live stream in...</span>
 
   <ul class="countdown-timer list-inline">
@@ -18,8 +18,6 @@
     <li class="countdown-minutes">42</li>
     <li class="countdown-seconds">37</li>
   </ul>
-
-  <a class="btn countdown-btn" href="#">Remind Me</a>
 </div>
     </ddk-example>
   </div>


### PR DESCRIPTION
Add updated countdown markup to CR homepage. Modifying the markup to more accurately reflect the correct implementation.

Created a new component on CMS called `countdown_test` to test new layout. Will need to be moved to `countdown` content-block after code freeze (I think? 🤔).

Corresponds with crdschurch/crds-styles#137