### PR TITLE
US8773 - Card style tweaks

### DIFF
--- a/src/app/ui-components/cards/types/types.component.html
+++ b/src/app/ui-components/cards/types/types.component.html
@@ -48,7 +48,7 @@
     alt="Card image caption">
   <div class="card-block text-center card-caption">
     <h4 class="card-title">Card title</h4>
-    <h5 class="card-subtitle text-muted">Card subtitle</h5>
+    <h5 class="card-subtitle">Card subtitle</h5>
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
     <a href="#" class="card-link">Go somewhere</a>
   </div>
@@ -59,7 +59,7 @@
 <section>
   <h3 class="component-header">Cards and Utility Classes</h3>
 
-  <p>Cards can use utility classes to modify their appearance. Here, the text has been centered and color adjusted using <code>.text-center</code> and <code>.text-muted</code>.</p>
+  <p>Cards can use utility classes to modify their appearance. Here, the text has been centered using <code>.text-center</code>.</p>
 
   <ddk-example>
 <div class="card">
@@ -67,7 +67,7 @@
     alt="Card image caption">
   <div class="card-block text-center">
     <h4 class="card-title">Card title</h4>
-    <h5 class="card-subtitle text-muted">Card subtitle</h5>
+    <h5 class="card-subtitle">Card subtitle</h5>
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
     <a href="#" class="card-link">Go somewhere</a>
   </div>


### PR DESCRIPTION
Remove the .text-muted class from card examples. This is redundant now that this class sets a default color of light-gray.

Corresponds with crdschurch/crds-styles#138

---
Feedback from Rob: 

*Cards*
- All `.card { margin-bottom: 1rem; }` `.card-block { font-size: 14px;` }
- Default, h5 `color: $cr-gray-light`
- Card w/ Caption label  `.card-caption:before { top: -30px; font-size: 13px;}`