### PR TITLE
US8725 - Jumbotron Revisions

### DIFF
--- a/src/app/ui-components/jumbotrons/jumbotrons.component.html
+++ b/src/app/ui-components/jumbotrons/jumbotrons.component.html
@@ -72,9 +72,14 @@
     </p>
 
     <p>
-      If the background video has a <code>.video-trigger</code> anchor, clicking
-      it will trigger creating an embedded player on top of the jumbotron
-      content.
+      In this example, the script uses a <code>data-video-id</code> attribute
+      on the container to know which video to load in the background.
+    </p>
+
+    <p>
+      This example also shows an icon that triggers a video to play inline with
+      the container, covering the content. This is also done using the YouTube
+      Iframe API and a <code>data-video-id</code> attribute on the trigger.
     </p>
 
     <ddk-example height="450" id="jumbotron-video"></ddk-example>

--- a/src/app/ui-components/jumbotrons/jumbotrons.component.html
+++ b/src/app/ui-components/jumbotrons/jumbotrons.component.html
@@ -84,5 +84,29 @@
 
     <ddk-example height="450" id="jumbotron-video"></ddk-example>
 
+    <h3 class="component-header">
+      Sizes
+    </h3>
+
+    <p>
+      You can adjust the height of the jumbotron by adding a sizing class, as
+      shown below.
+    </p>
+
+    <ddk-example>
+<div class="jumbotron jumbotron-sm">
+  <h1 class="title">the main heading</h1>
+</div>
+<div class="jumbotron jumbotron-md">
+  <h1 class="title">the main heading</h1>
+</div>
+<div class="jumbotron jumbotron-lg">
+  <h1 class="title">the main heading</h1>
+</div>
+<div class="jumbotron jumbotron-xl">
+  <h1 class="title">the main heading</h1>
+</div>
+    </ddk-example>
+
   </div>
 </div>

--- a/src/examples/jumbotron-video/index.html
+++ b/src/examples/jumbotron-video/index.html
@@ -12,19 +12,22 @@
   <body>
 
     <div class="jumbotron bg-video" data-video-id="DzlH5SDGoyA">
-    <!--<div class="jumbotron bg-video" >-->
       <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader preloader--top-right preloader--small">
+        <svg viewBox="0 0 102 101"
+             class="preloader preloader--top-right preloader--small">
           <g fill="none" fill-rule="evenodd">
             <g transform="translate(1 1)" stroke-width="4">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
+              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50"
+                       ry="49.421"></ellipse>
+              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0"
+                    stroke-opacity=".631" stroke="#3B6E8F"></path>
             </g>
           </g>
         </svg>
       </div>
       <div class="bg-video-player"></div>
-      <a href="#" class="video-trigger">
+      <div class="inline-video-player"></div>
+      <a href="#" class="video-trigger" data-video-id="Dod2VzUFNW0">
         <svg class="icon icon-5" viewBox="0 0 256 256">
           <use xmlns:xlink="http://www.w3.org/1999/xlink"
               xlink:href="/assets/svgs/icons.svg#play-thin"></use>

--- a/src/examples/jumbotron-video/index.html
+++ b/src/examples/jumbotron-video/index.html
@@ -13,9 +13,9 @@
 
     <div class="jumbotron bg-video">
       <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
+        <svg viewBox="0 0 102 101" class="preloader preloader--top-right preloader--small">
           <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
+            <g transform="translate(1 1)" stroke-width="4">
               <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
               <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
             </g>

--- a/src/examples/jumbotron-video/index.html
+++ b/src/examples/jumbotron-video/index.html
@@ -11,7 +11,8 @@
   </head>
   <body>
 
-    <div class="jumbotron bg-video">
+    <div class="jumbotron bg-video" data-video-id="DzlH5SDGoyA">
+    <!--<div class="jumbotron bg-video" >-->
       <div class="preloader-wrapper">
         <svg viewBox="0 0 102 101" class="preloader preloader--top-right preloader--small">
           <g fill="none" fill-rule="evenodd">
@@ -22,10 +23,7 @@
           </g>
         </svg>
       </div>
-      <div class="bg-video-player">
-        <!-- Use a unique ID for your player -->
-        <div id="crds-bg-video"></div>
-      </div>
+      <div class="bg-video-player"></div>
       <a href="#" class="video-trigger">
         <svg class="icon icon-5" viewBox="0 0 256 256">
           <use xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/src/examples/jumbotron-video/index.html
+++ b/src/examples/jumbotron-video/index.html
@@ -26,7 +26,14 @@
         </svg>
       </div>
       <div class="bg-video-player"></div>
-      <div class="inline-video-player"></div>
+      <div class="inline-video-player">
+        <a href="#" class="close-video">
+          <svg class="icon icon-2" viewBox="0 0 256 256">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                xlink:href="/assets/svgs/icons.svg#close"></use>
+          </svg>
+        </a>
+      </div>
       <a href="#" class="video-trigger" data-video-id="Dod2VzUFNW0">
         <svg class="icon icon-5" viewBox="0 0 256 256">
           <use xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/src/examples/jumbotron-video/video.js
+++ b/src/examples/jumbotron-video/video.js
@@ -13,18 +13,27 @@ function onYouTubeIframeAPIReady() {
     return true;
   }
 
-  new CRDS.JumbotronVideoPlayer({
-    videoId: 'DzlH5SDGoyA',
-    playerId: 'crds-bg-video'
-  });
+  var videoPlayers = document.querySelectorAll('.jumbotron.bg-video')
+
+  for (i = 0; i < videoPlayers.length; i++) {
+    new CRDS.JumbotronVideoPlayer(videoPlayers[i]);
+  }
 }
 
-CRDS.JumbotronVideoPlayer = function(options = {}) {
-  this.videoId = options.videoId;
-  this.playerId = options.playerId;
-  this.playerEl = document.getElementById(this.playerId);
-  this.playerContainerEl = this.playerEl.parentElement;
-  this.jumbotronEl = this.playerContainerEl.parentElement;
+CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
+  this.jumbotronEl = jumbotronEl;
+  this.playerContainerEl = this.jumbotronEl.querySelector('.bg-video-player');
+  this.playerId = 'video-player-' + Math.random().toString(36).substr(2, 10);
+
+  this.playerEl = document.createElement('div');
+  this.playerEl.setAttribute('id', this.playerId);
+  this.playerContainerEl.appendChild(this.playerEl)
+
+  this.videoId = this.jumbotronEl.getAttribute('data-video-id');
+  if (!this.videoId) {
+    throw 'data-player-id is required on the jumbotron containing element.';
+  }
+
   this.preloaderContainerEl = this.jumbotronEl.querySelector('.preloader-wrapper');
   this.preloaderEl = this.jumbotronEl.querySelector('.preloader');
   this.videoTrigger = this.jumbotronEl.querySelector('.video-trigger');

--- a/src/examples/jumbotron-video/video.js
+++ b/src/examples/jumbotron-video/video.js
@@ -146,6 +146,12 @@ CRDS.JumbotronVideoPlayer.prototype.bindEvents = function() {
     event.preventDefault();
     _this.playInlineVideo();
   }, true);
+
+  var closeTrigger = this.inlinePlayerContainerEl.querySelector('.close-video');
+  closeTrigger.addEventListener('click', function(event) {
+    event.preventDefault();
+    _this.stopInlineVideo();
+  }, true);
 };
 
 CRDS.JumbotronVideoPlayer.prototype.initInlineVideo = function() {
@@ -165,18 +171,22 @@ CRDS.JumbotronVideoPlayer.prototype.initInlineVideo = function() {
   return true;
 };
 
-
 CRDS.JumbotronVideoPlayer.prototype.playInlineVideo = function() {
   if (!this.inlinePlayer) {
     this.initInlineVideo();
     return true;
   }
   this.inlinePlayerContainerEl.classList.add('active');
-  this.inlinePlayer.playVideo;
+  this.inlinePlayer.playVideo();
+};
+
+CRDS.JumbotronVideoPlayer.prototype.stopInlineVideo = function() {
+  this.inlinePlayerContainerEl.classList.remove('active');
+  this.inlinePlayer.stopVideo();
 };
 
 CRDS.JumbotronVideoPlayer.prototype.onInlineVideoStateChange = function(event) {
   if (event.data == YT.PlayerState.ENDED) {
-    this.inlinePlayerContainerEl.classList.remove('active');
+    this.stopInlineVideo();
   }
 };

--- a/src/examples/jumbotron-video/video.js
+++ b/src/examples/jumbotron-video/video.js
@@ -79,9 +79,6 @@ CRDS.JumbotronVideoPlayer.prototype.resizePlayer = function() {
       height = this.jumbotronEl.offsetHeight,
       ratio = 16 / 9;
 
-  // Put the preloader in the middle of the container.
-  this.preloaderEl.style.top = ((height / 2) - 37.5) + 'px';
-
   // If the container is wider than the desired ratio ...
   if (width / height > ratio) {
     // The new width should be the width of the container,


### PR DESCRIPTION
- `.container .jumbotron, .container-fluid .jumbotron { border-radius: 0; }`
- `.jumbotron { padding-top: 150px; padding-bottom: 150px; }` <-- (100px @ mobile) 
- `.jumbotron .small-heading { font-size: .85rem; line-height: 1; opacity: .8;}`
- `.jumbotron .title { margin: 1rem 0; }`
- `.jumbotron a.btn { margin: 1rem .25rem 0; }`
- Padding helper: Default to 48px. Then small (32px), large (80px), xlarge (112px). 
- Move loading spinner to top right corner of container; make smaller
- support different video for bkg & button
- both video links should be editable via CMS
- add close btn while video is playing 
- automatically go back to jumbotron once video ends

---

Corresponds with crdschurch/crds-styles#141 and crdschurch/crds-maestro#150.
