### PR TITLE
DE3687 - Modal Close

### DIFF
--- a/src/examples/video-modals/video-modal.component.html
+++ b/src/examples/video-modals/video-modal.component.html
@@ -3,10 +3,10 @@
 <div bsModal #modal="bs-modal" class="modal fade video-modal">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
-      <button type="button" class="close pull-right" (click)="modal.hide()">
-        <span>&times;</span>
-      </button>
       <div class="modal-body">
+        <button type="button" class="close pull-right" (click)="modal.hide()">
+          <span>&times;</span>
+        </button>
         <iframe [src]="videoSrc" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>


### PR DESCRIPTION
Make button on video modals close the modal.

This defect also applies to int, but can be viewed on int without any local changes (assuming cache has cleared since I made the last markup change).