### PR TITLE
US8429 - Block Level Buttons

### DIFF
--- a/src/app/ui-components/ui-components.module.ts
+++ b/src/app/ui-components/ui-components.module.ts
@@ -42,6 +42,7 @@ import { ImagesComponent } from './utilities/images/images.component';
 import { MarginComponent } from './utilities/margin/margin.component';
 import { PaddingComponent } from './utilities/padding/padding.component';
 import { TextComponent } from './utilities/text/text.component';
+import { ButtonUtilitiesComponent } from './utilities/buttons/buttons.component';
 import { VerticalPositioningComponent } from './utilities/vertical-positioning/vertical-positioning.component';
 
 /* feedback */
@@ -161,6 +162,7 @@ import { FauxdalsComponent } from './fauxdals/fauxdals.component';
     MarginComponent,
     PaddingComponent,
     TextComponent,
+    ButtonUtilitiesComponent,
     VerticalPositioningComponent,
 
     /* feedback */
@@ -227,7 +229,7 @@ import { FauxdalsComponent } from './fauxdals/fauxdals.component';
     JumbotronsComponent,
 
     /* modals */
-    VideoModalsComponent, 
+    VideoModalsComponent,
 
     /* fauxdals */
     FauxdalsComponent

--- a/src/app/ui-components/ui-routing.module.ts
+++ b/src/app/ui-components/ui-routing.module.ts
@@ -31,6 +31,7 @@ import { ImagesComponent } from './utilities/images/images.component';
 import { MarginComponent } from './utilities/margin/margin.component';
 import { PaddingComponent } from './utilities/padding/padding.component';
 import { TextComponent } from './utilities/text/text.component';
+import { ButtonUtilitiesComponent } from './utilities/buttons/buttons.component';
 import { VerticalPositioningComponent } from './utilities/vertical-positioning/vertical-positioning.component';
 
 /* Feedback */
@@ -171,6 +172,10 @@ const uiRoutes: Routes = [
           {
             path: 'text',
             component: TextComponent
+          },
+          {
+            path: 'buttons',
+            component: ButtonUtilitiesComponent
           },
           {
             path: 'vertical-positioning',

--- a/src/app/ui-components/utilities/buttons/buttons.component.html
+++ b/src/app/ui-components/utilities/buttons/buttons.component.html
@@ -1,0 +1,29 @@
+<h2 class="page-header">Buttons</h2>
+
+<p>
+  The following utilities exist to aid buttons, in addition to the
+  standard options for <a routerLink="/ui/buttons">buttons</a>.
+</p>
+
+<p class="alert alert-info">
+  Note that the <code>-mobile</code> class extension applies the code only for
+  screens smaller than <code>$screen-xs-max</code> (a Bootstrap SCSS variable).
+</p>
+
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th class="col-sm-3">Group of Classes</th>
+      <th class="col-sm-9">CSS</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td class="col-sm-3"><code>.btn-block-mobile</code></td>
+      <td class="col-sm-9"><code>display: block;</code><br>
+        <code>width: 100%;</code><br>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/ui-components/utilities/buttons/buttons.component.spec.ts
+++ b/src/app/ui-components/utilities/buttons/buttons.component.spec.ts
@@ -1,0 +1,9 @@
+import { TestBed } from '@angular/core/testing';
+import { ButtonUtilitiesComponent } from './buttons.component';
+
+describe('Component: Buttons', () => {
+  it('should create an instance', () => {
+    let component = new ButtonUtilitiesComponent();
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/ui-components/utilities/buttons/buttons.component.ts
+++ b/src/app/ui-components/utilities/buttons/buttons.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  templateUrl: './buttons.component.html'
+})
+
+export class ButtonUtilitiesComponent {}

--- a/src/app/ui-components/utilities/utilities.component.html
+++ b/src/app/ui-components/utilities/utilities.component.html
@@ -26,6 +26,9 @@
             <a routerLink="/ui/utilities/text">Text</a>
           </li>
           <li routerLinkActive="active" class="list-group-item">
+            <a routerLink="/ui/utilities/buttons">Buttons</a>
+          </li>
+          <li routerLinkActive="active" class="list-group-item">
             <a routerLink="/ui/utilities/vertical-positioning">Vertical Positioning</a>
           </li>
         </ul>

--- a/src/examples/datepicker/index.html
+++ b/src/examples/datepicker/index.html
@@ -20,8 +20,44 @@
   </head>
 
   <body>
+
+    <style>
+      @keyframes rotateInitLoadingSpinner {
+        100% {
+          transform:rotate(360deg);
+        }
+      }
+      .preloader {
+        position: absolute;
+        display: block;
+        top: 48px;
+        left: calc(50% - 37.5px);
+        width: 75px;
+        height: 75px;
+        margin: 0 auto;
+        background: transparent;
+        animation: rotateInitLoadingSpinner 700ms linear infinite;
+      }
+      .preloader-wrapper {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    </style>
+
     <my-app>
-    loading...
-  </my-app>
+      <div class="preloader-wrapper">
+        <svg viewBox="0 0 102 101" class="preloader">
+          <g fill="none" fill-rule="evenodd">
+            <g transform="translate(1 1)" stroke-width="2">
+              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </my-app>
   </body>
 </html>

--- a/src/examples/jumbotron-video/index.html
+++ b/src/examples/jumbotron-video/index.html
@@ -12,9 +12,9 @@
   <body>
 
     <div class="jumbotron bg-video" data-video-id="DzlH5SDGoyA">
-      <div class="preloader-wrapper">
+      <div class="inline-preloader-wrapper">
         <svg viewBox="0 0 102 101"
-             class="preloader preloader--top-right preloader--small">
+             class="inline-preloader inline-preloader--top-right inline-preloader--small">
           <g fill="none" fill-rule="evenodd">
             <g transform="translate(1 1)" stroke-width="4">
               <ellipse stroke="#eee" cx="50" cy="49.421" rx="50"

--- a/src/examples/jumbotron-video/video.js
+++ b/src/examples/jumbotron-video/video.js
@@ -34,8 +34,8 @@ CRDS.JumbotronVideoPlayer = function(jumbotronEl) {
     throw 'data-player-id is required on the jumbotron containing element.';
   }
 
-  this.preloaderContainerEl = this.jumbotronEl.querySelector('.preloader-wrapper');
-  this.preloaderEl = this.jumbotronEl.querySelector('.preloader');
+  this.preloaderContainerEl = this.jumbotronEl.querySelector('.inline-preloader-wrapper');
+  this.preloaderEl = this.jumbotronEl.querySelector('.inline-preloader');
   this.inlineVideoTrigger = this.jumbotronEl.querySelector('.video-trigger');
   this.inlineVideoId = this.inlineVideoTrigger.getAttribute('data-video-id') ||
                        this.bgVideoId;

--- a/src/examples/map/index.html
+++ b/src/examples/map/index.html
@@ -21,6 +21,32 @@
 
   <body>
 
+    <style>
+      @keyframes rotateInitLoadingSpinner {
+        100% {
+          transform:rotate(360deg);
+        }
+      }
+      .preloader {
+        position: absolute;
+        display: block;
+        top: 48px;
+        left: calc(50% - 37.5px);
+        width: 75px;
+        height: 75px;
+        margin: 0 auto;
+        background: transparent;
+        animation: rotateInitLoadingSpinner 700ms linear infinite;
+      }
+      .preloader-wrapper {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    </style>
+
     <app-root data-iframe-height>
       <div class="preloader-wrapper">
         <svg viewBox="0 0 102 101" class="preloader">

--- a/src/examples/toastr/index.html
+++ b/src/examples/toastr/index.html
@@ -27,9 +27,9 @@
         }
       }
       .preloader {
-        position: fixed;
+        position: absolute;
         display: block;
-        top: calc(20% - 37.5px);
+        top: 32px;
         left: calc(50% - 37.5px);
         width: 75px;
         height: 75px;
@@ -38,7 +38,7 @@
         animation: rotateInitLoadingSpinner 700ms linear infinite;
       }
       .preloader-wrapper {
-        position: fixed;
+        position: absolute;
         top: 0;
         bottom: 0;
         left: 0;

--- a/src/examples/video-modals/index.html
+++ b/src/examples/video-modals/index.html
@@ -21,6 +21,32 @@
 
   <body>
 
+    <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform:rotate(360deg);
+      }
+    }
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+    </style>
+
     <app-root data-iframe-height>
       <div class="preloader-wrapper">
         <svg viewBox="0 0 102 101" class="preloader">


### PR DESCRIPTION
Given a developer viewing the DDK
When I view utility classes
Then i should see the .btn-block-mobile selector with a description of what it will do to help me make awesome buttons. 

Given a user viewing /connect
When I view a CTA throughout the application on mobile
Then it should be displayed 100% wide, block-level on my tiny screen

Given a user viewing /connect
When I view a CTA throughout the application on desktop
Then I should see inline-block elements that do not fill up 100% of my screen width. 

---

Corresponds with:

- crdschurch/crds-styles#142
- crdschurch/crds-maestro#151
- crdschurch/crds-connect#411