### PR TITLE
US9342 - Social icons

### DIFF
--- a/src/app/directives/icons/icons.service.ts
+++ b/src/app/directives/icons/icons.service.ts
@@ -21,6 +21,7 @@ export class IconService {
     'facebook',
     'github',
     'instagram',
+    'link',
     'map-marker',
     'menu',
     'play-thin',


### PR DESCRIPTION
Add link icon to DDK.

Modify the group detail view such that the social icons appear outside of the expanded description field. User should not have to expand description to access the social icons to share the group. Defer to Rob for positioning as needed. 

Also we need to add a link icon so the user can copy the direct URL to the group.

Corresponds with crdschurch/crds-styles#180
Corresponds with crdschurch/crds-connect#540