### PR TITLE
Defect/de4029 search btn width

### DIFF
--- a/src/app/ui-components/forms/search/search.component.html
+++ b/src/app/ui-components/forms/search/search.component.html
@@ -8,16 +8,18 @@
 </p>
 
 <ddk-example>
+<form class="searchbar">
   <div class="input-group">
     <input type="text" class="form-control" placeholder="Search ...">
     <span class="input-group-btn">
-    <button type="submit" class="btn btn-secondary">
-      <svg class="icon icon-1" viewBox="0 0 256 256">
-        <use xlink:href="/assets/svgs/icons.svg#search"></use>
-      </svg>
-    </button>
-  </span>
+      <button type="submit" class="btn btn-secondary">
+        <svg class="icon icon-1" viewBox="0 0 256 256">
+          <use xlink:href="/assets/svgs/icons.svg#search"></use>
+        </svg>
+      </button>
+    </span>
   </div>
+</form>
 </ddk-example>
 
 <h3 class="component-header">Search with Clickable Addon</h3>


### PR DESCRIPTION
Update the markup so both searchbars match in implementation.

---
Searchbar search button doesn't have correct width in IE 10 and 11. Might be inheriting table-cell display from bootstrap. 

Search button should be a reasonable width and not crazy wide.

Corresponds with crdschurch/crds-styles#192