### PR TITLE
Feature/us9483 add callouts

### DIFF
--- a/src/app/ui-components/atoms/buttons/groups/groups.component.html
+++ b/src/app/ui-components/atoms/buttons/groups/groups.component.html
@@ -1,8 +1,6 @@
 <h2 class="page-header">Groups</h2>
 
-<div class="alert alert-info">
-  <p>For a button to have an active state, the class <code>active</code> must be added to the selector. This can be done using either <a href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#class-binding" target="_blank" class="alert-link">class binding</a>, .e.g. <code>&#91;class.active&#93;="isActive"</code>, or with the <a href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#ngClass" target="_blank" class="alert-link">NgClass directive</a>, e.g. <code>&#91;ngClass&#93;="&#123;'active'&#125;"</code>.</p>
-</div>
+<p class="callout callout-info">For a button to have an active state, the class <code>active</code> must be added to the selector. This can be done using either <a href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#class-binding" target="_blank" class="callout-link">class binding</a>, .e.g. <code>&#91;class.active&#93;="isActive"</code>, or with the <a href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#ngClass" target="_blank" class="callout-link">NgClass directive</a>, e.g. <code>&#91;ngClass&#93;="&#123;'active'&#125;"</code>.</p>
 
 <h3 class="component-header">Button Group - Horizontal</h3>
 

--- a/src/app/ui-components/atoms/buttons/groups/groups.component.html
+++ b/src/app/ui-components/atoms/buttons/groups/groups.component.html
@@ -61,7 +61,7 @@
 
 <h3 class="component-header">Toggle Button Group</h3>
 
-<div class="alert alert-info" role="alert">This button group component requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="alert-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/buttons#radio" target="_blank" class="alert-link">this documentation</a> when customizing this component.</div>
+<p class="callout callout-info" role="alert">This button group component requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="callout-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/buttons#radio" target="_blank" class="callout-link">this documentation</a> when customizing this component.</p>
 
 <ddk-example>
   <div class="btn-group btn-group-toggle btn-group-teal">

--- a/src/app/ui-components/atoms/buttons/styles/styles.component.html
+++ b/src/app/ui-components/atoms/buttons/styles/styles.component.html
@@ -76,11 +76,9 @@
   dropdown.
 </p>
 
-<div class="alert alert-info" role="alert">
-  The dropdown behavior requires the inclusion of
+<p class="callout callout-info" role="alert">The dropdown behavior requires the inclusion of
   <a href="http://valor-software.com/ngx-bootstrap/#/"
-     target="_blank" class="alert-link">NGX Bootstrap</a> - an external
-  resource used to create Bootstrap-like elements in Angular 2 applications.
-</div>
+     target="_blank" class="callout-link">NGX Bootstrap</a> - an external
+  resource used to create Bootstrap-like elements in Angular 2 applications.</p>
 
 <ddk-example id="button-dropdown" height="200"></ddk-example>

--- a/src/app/ui-components/atoms/feedback/alerts/alerts.component.html
+++ b/src/app/ui-components/atoms/feedback/alerts/alerts.component.html
@@ -1,5 +1,6 @@
 <h2 class="page-header">Alert Messages</h2>
 
+<p>Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages.</p>
 <p>Wrap any text in <code>.alert</code> and a contextual class to create an alert message.</p>
 
 <br>

--- a/src/app/ui-components/atoms/forms/datepicker/datepicker.component.html
+++ b/src/app/ui-components/atoms/forms/datepicker/datepicker.component.html
@@ -1,5 +1,5 @@
 <h2 class="page-header">Datepicker</h2>
 
-<div class="alert alert-info" role="alert">The <code>&lt;datepicker&gt;</code> element requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="alert-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/datepicker" target="_blank" class="alert-link">this documentation</a> when customizing this component.</div>
+<p class="callout callout-info" role="alert">The <code>&lt;datepicker&gt;</code> element requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="callout-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/datepicker" target="_blank" class="callout-link">this documentation</a> when customizing this component.</p>
 
 <ddk-example id="datepicker" height="330"></ddk-example>

--- a/src/app/ui-components/atoms/forms/form-states/form-states.component.html
+++ b/src/app/ui-components/atoms/forms/form-states/form-states.component.html
@@ -2,7 +2,7 @@
 
 <p>Validation states are a great way to provide visual feedback when filling out a form. Angular can use the <code>ngModel</code> directive to track the state and validity of the form.</p>
 
-<div class="alert alert-info" role="alert">Documentation for Angular 2 form validation can be found <a href="https://angular.io/docs/ts/latest/guide/forms.html" target="_blank" class="alert-link">here</a>.</div>
+<p class="callout callout-info" role="alert">Documentation for Angular 2 form validation can be found <a href="https://angular.io/docs/ts/latest/guide/forms.html" target="_blank" class="callout-link">here</a>.</p>
 
 <h3 class="component-header">Input Field &mdash; Focus</h3>
 

--- a/src/app/ui-components/atoms/forms/timepicker/timepicker.component.html
+++ b/src/app/ui-components/atoms/forms/timepicker/timepicker.component.html
@@ -1,5 +1,5 @@
 <h2 class="page-header">Timepicker</h2>
 
-<div class="alert alert-info" role="alert">The <code>&lt;timepicker&gt;</code> element requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="alert-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/timepicker" target="_blank" class="alert-link">this documentation</a> when customizing this component.</div>
+<p class="callout callout-info" role="alert">The <code>&lt;timepicker&gt;</code> element requires the inclusion of <a href="https://github.com/valor-software/ngx-bootstrap" target="_blank" class="callout-link">NG-2 Bootstrap</a> - an external resource used to create Bootstrap-like elements in Angular 2 applications. Please refer to <a href="http://valor-software.com/ngx-bootstrap/#/timepicker" target="_blank" class="callout-link">this documentation</a> when customizing this component.</p>
 
 <ddk-example id="timepicker" height="200"></ddk-example>

--- a/src/app/ui-components/atoms/icons/inline-svg/inline-svg.component.html
+++ b/src/app/ui-components/atoms/icons/inline-svg/inline-svg.component.html
@@ -7,7 +7,7 @@ view the options in the <a routerLink="/ui-components/atoms/icons/directory">ico
 
 <p>It's imperative that you include the <code>viewBox</code> attribute as shown below.</p>
 
-<div class="alert alert-info" role="alert">Prefixing the <code>href</code> attribute with <code>xlink:</code> is required for SVG images to display in Safari and iOS devices.</div>
+<p class="callout callout-info" role="alert">Prefixing the <code>href</code> attribute with <code>xlink:</code> is required for SVG images to display in Safari and iOS devices.</p>
 
 <div class="row">
   <div class="col-sm-6" *ngFor="let icon of icons">

--- a/src/app/ui-components/core/colors/text/text.component.html
+++ b/src/app/ui-components/core/colors/text/text.component.html
@@ -2,7 +2,7 @@
 
 <p>Here you'll find additional text utility classes, altering the color of any given text. These classes can be used similarly to the contextual color classes found in <a href="http://getbootstrap.com/docs/3.3/css/#helper-classes-colors" target="_blank">Bootstrap's documentation</a>.</p>
 
-<div class="alert alert-info" role="alert">A dark background has been applied to the <code>.text-white</code> code example so you can see the text and the class' impact on said text.</div>
+<p class="callout callout-info" role="alert">A dark background has been applied to the <code>.text-white</code> code example so you can see the text and the class' impact on said text.</p>
 
 <ddk-example>
 <div class="bg-charcoal">

--- a/src/app/ui-components/core/typography/typefaces/typefaces.component.html
+++ b/src/app/ui-components/core/typography/typefaces/typefaces.component.html
@@ -1,8 +1,6 @@
 <h2 class="page-header">Typefaces</h2>
 
-<div class="alert alert-warning">
-  <p>The class selectors defined below require the inclusion of Crossroad's custom library of web-fonts. <a routerLink="/ui-components/core/typography/web-fonts" class="alert-link">Click here</a> to learn more about including web-fonts in your project.</p>
-</div>
+<p class="callout callout-warning">The class selectors defined below require the inclusion of Crossroad's custom library of web-fonts. <a routerLink="/ui-components/core/typography/web-fonts" class="callout-link">Click here</a> to learn more about including web-fonts in your project.</p>
 
 <p>By default, all elements will inherit the base font-family <a href="https://typekit.com/fonts/acumin">Acumin Pro</a>.</p>
 

--- a/src/app/ui-components/core/typography/typesetting/typesetting.component.html
+++ b/src/app/ui-components/core/typography/typesetting/typesetting.component.html
@@ -1,9 +1,6 @@
 <h2 class="page-header">Typesetting</h2>
 
-<div class="alert alert-warning">
-  <p>In order to achieve a balance of both readability &amp; relative scale across the entire codebase, we've selected a base-font size of <code>16px</code> since that is the number most commonly associated with modern browser defaults, e.g. <code>16px = 1rem</code>.
-    Accordingly, this value has been used to override Bootstrap's <code>$font-size-base</code> variable.</p>
-</div>
+<p class="callout callout-warning">In order to achieve a balance of both readability &amp; relative scale across the entire codebase, we've selected a base-font size of <code>16px</code> since that is the number most commonly associated with modern browser defaults, e.g. <code>16px = 1rem</code>. Accordingly, this value has been used to override Bootstrap's <code>$font-size-base</code> variable.</p>
 
 <h3 id="headings" class="component-header">Headings</h3>
 
@@ -128,7 +125,7 @@
   </ddk-example>
 </div>
 
-<div class="alert alert-info" role="alert">All link styles can be combined with other utility classes, i.e., <code>.pull-right</code> or <code>.font-size-small</code> to alter look or layout.</div>
+<p class="callout callout-info" role="alert">All link styles can be combined with other utility classes, i.e., <code>.pull-right</code> or <code>.font-size-small</code> to alter look or layout.</p>
 
 <ddk-example>
   <div class="clearfix">

--- a/src/app/ui-components/core/typography/web-fonts/web-fonts.component.html
+++ b/src/app/ui-components/core/typography/web-fonts/web-fonts.component.html
@@ -13,6 +13,4 @@
 
 <br>
 
-<div class="alert alert-warning">
-  <p>When working on or deploying applications that are new to the organization, you may need to work with your product owner to include the domain for your project within the <em>"allowed domains"</em> whitelist in Typekit.</p>
-</div>
+<p class="callout callout-warning">When working on or deploying applications that are new to the organization, you may need to work with your product owner to include the domain for your project within the <em>"allowed domains"</em> whitelist in Typekit.</p>

--- a/src/app/ui-components/core/utilities/buttons/buttons.component.html
+++ b/src/app/ui-components/core/utilities/buttons/buttons.component.html
@@ -5,7 +5,7 @@
   standard options for <a routerLink="/ui-components/buttons">buttons</a>.
 </p>
 
-<p class="alert alert-info">
+<p class="callout callout-info">
   Note that the <code>-mobile</code> class extension applies the code only for
   screens smaller than <code>$screen-xs-max</code> (a Bootstrap SCSS variable).
 </p>

--- a/src/app/ui-components/core/utilities/images/images.component.html
+++ b/src/app/ui-components/core/utilities/images/images.component.html
@@ -52,7 +52,7 @@
 
 <h3 class="component-header">Image Positioning</h3>
 
-<div class="alert alert-info" role="alert">An element with <code>position: absolute;</code> will position itself within the context of it's closest <code>position: relative;</code> parent.</div>
+<p class="callout callout-info" role="alert">An element with <code>position: absolute;</code> will position itself within the context of it's closest <code>position: relative;</code> parent.</p>
 
 <table class="table table-striped table-bordered">
   <thead>

--- a/src/app/ui-components/core/utilities/margin/margin.component.html
+++ b/src/app/ui-components/core/utilities/margin/margin.component.html
@@ -4,7 +4,7 @@
 
 <p>Adding a class of <code>.push-*</code> to an element will increase its desired margin.</p>
 
-<div class="alert alert-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to increase the right margin on small devices only, you'd use the class <code>.mobile-push-right</code> instead of <code>.push-right</code>.</div>
+<p class="callout callout-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to increase the right margin on small devices only, you'd use the class <code>.mobile-push-right</code> instead of <code>.push-right</code>.</p>
 
 <p><strong>Please Note:</strong> <code>.push-*</code> classes rely on the Bootstrap-defined variable, <code>$line-height-computed</code>. See documentation for that variable <a href="http://getbootstrap.com/docs/3.3/customize/#typography" target="_blank">here</a>.</p>
 
@@ -110,7 +110,7 @@
 
 <p>Adding a class of <code>.flush-*</code> to an element will decrease its desired margin.</p>
 
-<div class="alert alert-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to reduce the right margin on small devices only, you'd use the class <code>.mobile-flush-right</code> instead of <code>.flush-right</code>.</div>
+<p class="callout callout-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to reduce the right margin on small devices only, you'd use the class <code>.mobile-flush-right</code> instead of <code>.flush-right</code>.</p>
 
 <table class="table table-striped table-bordered">
   <thead>

--- a/src/app/ui-components/core/utilities/padding/padding.component.html
+++ b/src/app/ui-components/core/utilities/padding/padding.component.html
@@ -4,7 +4,7 @@
 
 <p>Adding a class of <code>.soft-*</code> to an element will increase its desired padding.</p>
 
-<div class="alert alert-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to increase the right padding on small devices only, you'd use the class <code>.mobile-soft-right</code> instead of <code>.soft-right</code>.</div>
+<div class="callout callout-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to increase the right padding on small devices only, you'd use the class <code>.mobile-soft-right</code> instead of <code>.soft-right</code>.</div>
 
 <p><strong>Please Note:</strong> <code>.soft-*</code> classes rely on the Bootstrap-defined variable, <code>$line-height-computed</code>. See documentation for that variable <a href="http://getbootstrap.com/docs/3.3/customize/#typography" target="_blank">here</a>.</p>
 
@@ -114,7 +114,7 @@
 
 <p>Adding a class of <code>.hard-*</code> to an element will decrease its desired padding.</p>
 
-<div class="alert alert-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to decrease the right padding on small devices only, you'd use the class <code>.mobile-hard-right</code> instead of <code>.hard-right</code>.</div>
+<p class="callout callout-info" role="alert">These classes also have mobile-friendly versions to allow for class stacking. To use, prepend <code>.mobile-</code> to any of the classes below. For example, if you wanted to decrease the right padding on small devices only, you'd use the class <code>.mobile-hard-right</code> instead of <code>.hard-right</code>.</p>
 
 <table class="table table-striped table-bordered">
   <thead>

--- a/src/app/ui-components/molecules/video-modals/video-modals.component.html
+++ b/src/app/ui-components/molecules/video-modals/video-modals.component.html
@@ -4,11 +4,8 @@
   <div class="col-md-offset-3">
     <h2 class="page-header">Video Modals</h2>
 
-    <div class="alert alert-info" role="alert">
-      Angular 2+ apps should use the
-      <a href="http://valor-software.com/ngx-bootstrap/#/">ngx-bootstrap library</a>
-      for implementing modal windows.
-    </div>
+    <p class="callout callout-info" role="alert">Angular 2+ apps should use the
+      <a href="http://valor-software.com/ngx-bootstrap/#/" class="callout-link">ngx-bootstrap library</a> for implementing modal windows.</p>
 
     <p>
       Modal windows displaying a video as its only content should include a

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -207,7 +207,7 @@ body.dark-theme {
   font-size: $font-size-small;
   font-style: italic;
   font-weight: 300;
-  line-height: 1.5;
+  line-height: 1.43;
   padding: 15px 21px;
 
   &.callout-info {
@@ -236,8 +236,7 @@ body.dark-theme {
   }
 
   code {
-    background-color: #faf2f4;
-    color: #d9004b;
+    font-family: $accent-font-face;
     font-size: $font-size-small;
   }
 }

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -197,3 +197,47 @@ body.dark-theme {
     padding-right: 0;
   }
 }
+
+.callout {
+  border: 1px solid rgba($cr-gray-light, .25);
+  border-left: 6px solid rgba($cr-gray-light, .25);
+  border-radius: 0;
+  color: $cr-gray-light;
+  font-family: $accent-font-face;
+  font-size: $font-size-small;
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1.5;
+  padding: 15px 21px;
+
+  &.callout-info {
+    border-left-color: $alert-info;
+  }
+
+  &.callout-success {
+    border-left-color: $alert-success;
+  }
+
+  &.callout-warning {
+    border-left-color: $alert-warning;
+  }
+
+  &.callout-danger {
+    border-left-color: $alert-danger;
+  }
+
+  .callout-link {
+    color: $link-color;
+    text-decoration: none;
+
+    &:hover {
+      color: $link-hover-color;
+    }
+  }
+
+  code {
+    background-color: #faf2f4;
+    color: #d9004b;
+    font-size: $font-size-small;
+  }
+}

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -20,3 +20,8 @@
     margin-top: 0.5em;
   }
 }
+
+code {
+  background-color: $code-bg;
+  color: $code-color;
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,7 @@
 $gray: #f5f5f5;
 $footer-background: $gray;
+$code-color: #d9004b;
+$code-bg: #faf2f4;
 
 // Bootstrap overrides for DDK dark-theme
 $navbar-inverse-bg: $cr-black;


### PR DESCRIPTION
As a user visiting the DDK
When I view a page with supplemental content (see notes)
Then I should see it styled as a callout instead of an alert

No related branches (this is a DDK specific style).