### PR TITLE
US9932 Update example for bg jumbotron video

### DIFF
--- a/src/app/ui-components/molecules/jumbotrons/jumbotrons.component.html
+++ b/src/app/ui-components/molecules/jumbotrons/jumbotrons.component.html
@@ -78,8 +78,8 @@
       </li>
       <li>
         The <code>video</code> tag has a class of <code>.hide</code> on it.
-        this is because the video element gets hidden from view until the
-        video has finished loading. Once loaded, javascript dynamically removes
+        This is because the video element gets hidden from view until the
+        video has finished loading. Once loaded, JavaScript dynamically removes
         that class from the <code>video</code> element.
       </li>
       <li>
@@ -89,8 +89,9 @@
       </li>
       <li>
         The <code>src</code> tag needs to point to an absolute url of where the video
-        is stored, and, according to HTML5 video tag documentation, that url should end
-        with a common video extension, such as .mp4.
+        is stored, and, according to 
+        <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video">HTML5 video tag documentation</a>,
+        that url should end with a common video extension, such as .mp4.
       </li>
     </ul>
 

--- a/src/app/ui-components/molecules/jumbotrons/jumbotrons.component.html
+++ b/src/app/ui-components/molecules/jumbotrons/jumbotrons.component.html
@@ -60,17 +60,39 @@
 
     <p>
       Jumbotrons also support background videos. This requires adding the
-      <code>.bg-video</code> selector, the player's elements, and JavaScript
-      customization using the
-      <a href="https://developers.google.com/youtube/iframe_api_reference">
-        YouTube IFrame API.
-      </a>
+      <code>.bg-video</code> selector, a nested <code>video</code> tag with
+      the selectors <code>.bg-jumbotron-video .hide</code>, and JavaScript
+      customization.
     </p>
 
     <p>
-      In this example, the script uses a <code>data-video-id</code> attribute
-      on the container to know which video to load in the background.
+      There are also a number of attributes that need to be considered when
+      adding background video to the jumbotron.
     </p>
+    <ul>
+      <li>
+        <code>data-aspect-ratio</code> should be added to the <code>
+        div.jumbotron.bg-video</code> element when the aspect ratio
+        of the provided video is anything other than 16/9.
+        <code>data-aspect-ratio</code> accepts numbers with decimals.
+      </li>
+      <li>
+        The <code>video</code> tag has a class of <code>.hide</code> on it.
+        this is because the video element gets hidden from view until the
+        video has finished loading. Once loaded, javascript dynamically removes
+        that class from the <code>video</code> element.
+      </li>
+      <li>
+        The attributes <code>autoplay</code>, <code>loop</code>, <code>muted</code>,
+        and <code>playsinline</code> are necessary to cause the video to start playing
+        after loading for all devices, both desktop and mobile.
+      </li>
+      <li>
+        The <code>src</code> tag needs to point to an absolute url of where the video
+        is stored, and, according to HTML5 video tag documentation, that url should end
+        with a common video extension, such as .mp4.
+      </li>
+    </ul>
 
     <ddk-example height="550" id="jumbotron-bg-video"></ddk-example>
 

--- a/src/examples/jumbotron-bg-video/bg-video.js
+++ b/src/examples/jumbotron-bg-video/bg-video.js
@@ -4,6 +4,7 @@ window['CRDS'] = window['CRDS'] || {};
 
 CRDS.JumbotronVideoPlayers = function() {
   this.bgVideoPlayers = document.querySelectorAll('.jumbotron.bg-video');
+  this.inlineVideoPlayers = document.querySelectorAll('.jumbotron.inline-video');
   if(typeof YT == 'object') {
     this.init();
   } else {
@@ -39,106 +40,36 @@ CRDS.JumbotronVideoPlayers.prototype.initVideos = function() {
     for (var i = 0; i < this.bgVideoPlayers.length; i++) {
       new CRDS.JumbotronBgVideoPlayer(this.bgVideoPlayers[i]);
     }
+    for (var i = 0; i < this.inlineVideoPlayers.length; i++) {
+      new CRDS.JumbotronInlineVideoPlayer(this.inlineVideoPlayers[i]);
+    }
   }
   return;
 }
 
 // ---------------------------------------- JumbotronBgVideoPlayer
 
-CRDS.JumbotronBgVideoPlayer = function(jumbotronEl) {
-  this.jumbotronEl = jumbotronEl;
+CRDS.JumbotronBgVideoPlayer = function(jumbotronBgVideo) {
+  this.mainJumbotronVideoEl = jumbotronBgVideo
+  this.player = document.querySelector(".bg-jumbotron-video");
+  this.playerContainerEl = document.querySelector(".bg-video-player");
   this.init();
+  this.resizePlayer();
   return;
 }
 
 CRDS.JumbotronBgVideoPlayer.prototype.init = function() {
-  this.playerContainerEl = this.jumbotronEl.querySelector('.bg-video-player');
-  this.playerId = 'video-player-' + Math.random().toString(36).substr(2, 10);
-
-  this.playerEl = document.createElement('div');
-  this.playerEl.setAttribute('id', this.playerId);
-  this.playerContainerEl.appendChild(this.playerEl);
-
-  this.videoId = this.jumbotronEl.getAttribute('data-video-id');
-  if (!this.videoId) {
-    throw 'data-player-id is required on the jumbotron containing element.';
-  }
-
-  this.playerOptions = {
-    autoplay: 0,
-    controls: 0,
-    modestbranding: 1,
-    loop: 1,
-    playsinline: 1,
-    showinfo: 0,
-    iv_load_policy: 3,
-    playlist: this.videoId // See: https://stackoverflow.com/a/25781957/2241124
-  };
-
-  this.preloader = document.createElement('div');
-  this.preloader.classList.add('inline-preloader-wrapper');
-  this.preloader.innerHTML = '\
-    <svg viewBox="0 0 102 101" class="inline-preloader inline-preloader--top-right inline-preloader--small"\>\
-      <g fill="none" fill-rule="evenodd"\>\
-        <g transform="translate(1 1)" stroke-width="2"\>\
-          <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"\></ellipse\>\
-          <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"\></path\>\
-        </g\>\
-      </g\>\
-    </svg\>';
-  this.jumbotronEl.insertBefore(this.preloader, this.jumbotronEl.firstChild);
-  this.preloaderContainerEl = this.jumbotronEl.querySelector('.inline-preloader-wrapper');
-  this.preloaderEl = this.jumbotronEl.querySelector('.inline-preloader');
-
-  return this.initVideo();
-};
-
-CRDS.JumbotronBgVideoPlayer.prototype.initVideo = function() {
   var _this = this;
-  this.player = new YT.Player(this.playerId, {
-    videoId: this.videoId,
-    playerVars: this.playerOptions,
-    events: {
-      onReady: function(event) {
-        _this.onVideoReady(event);
-        _this.playVideo();
-      },
-      onStateChange: function(event) {
-        _this.onVideoStateChange(event);
-      }
-    }
-  });
-  this.bindEvents();
-};
 
-CRDS.JumbotronBgVideoPlayer.prototype.playVideo = function() {
-  var _this = this;
-  if (!this.player.playVideo) {
-    setTimeout(function() {
-      _this.playVideo();
-    }, 250);
-    return true;
-  }
-  this.player.playVideo();
-};
-
-CRDS.JumbotronBgVideoPlayer.prototype.onVideoReady = function(event) {
-  this.resizePlayer();
-  event.target.mute();
-};
-
-CRDS.JumbotronBgVideoPlayer.prototype.onVideoStateChange = function(event) {
-  if (event.data == YT.PlayerState.PLAYING) {
-    this.preloaderContainerEl.classList.add('loaded');
-  } else {
-    this.preloaderContainerEl.classList.remove('loaded');
-  };
+  window.addEventListener('resize', function(event) {
+    _this.resizePlayer();
+  }, true);
 };
 
 CRDS.JumbotronBgVideoPlayer.prototype.resizePlayer = function() {
-  var width = this.jumbotronEl.offsetWidth,
-      height = this.jumbotronEl.offsetHeight,
-      ratio = parseFloat(this.jumbotronEl.getAttribute('data-aspect-ratio')) ||
+  var width = this.mainJumbotronVideoEl.offsetWidth,
+      height = this.mainJumbotronVideoEl.offsetHeight,
+      ratio = parseFloat(this.mainJumbotronVideoEl.getAttribute('data-aspect-ratio')) ||
               (16 / 9);
 
   // If the container is wider than the desired ratio ...
@@ -149,7 +80,8 @@ CRDS.JumbotronBgVideoPlayer.prototype.resizePlayer = function() {
         newHeight = width / ratio;
 
     // Resize the player.
-    this.player.setSize(newWidth, newHeight);
+    this.player.attributes.height.value = newHeight;
+    this.player.attributes.width.value = newWidth;
 
     // The player's container should sit at the left,
     // and at half of its excess height.
@@ -164,19 +96,109 @@ CRDS.JumbotronBgVideoPlayer.prototype.resizePlayer = function() {
         newWidth = height * ratio;
 
     // Resize the player.
-    this.player.setSize(newWidth, newHeight);
+    this.player.attributes.height.value = newHeight;
+    this.player.attributes.width.value = newWidth;
 
     // The player's container should sit at the top,
     // and at half of its excess width.
     this.playerContainerEl.style.top = 0;
     this.playerContainerEl.style.left = -((newWidth - width) / 2) + 'px';
   };
+  // This is to remove the visibility: hidden attribute from the video tag
+  this.player.classList.remove("hide");
 };
 
-CRDS.JumbotronBgVideoPlayer.prototype.bindEvents = function() {
+// ---------------------------------------- JumbotronInlineVideoPlayer
+
+CRDS.JumbotronInlineVideoPlayer = function(jumbotronEl) {
+  this.jumbotronEl = jumbotronEl;
+  this.init();
+  return;
+};
+
+CRDS.JumbotronInlineVideoPlayer.prototype.init = function() {
+  this.videoTrigger = this.jumbotronEl.querySelector('.inline-video-trigger');
+  if (this.videoTrigger && this.videoTrigger.innerHTML == '') {
+    this.videoTrigger.innerHTML = '\
+      <svg class="icon icon-5" viewBox="0 0 256 256"\>\
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#play-thin"></use\>\
+      </svg\>';
+  }
+
+  this.videoId = this.videoTrigger.getAttribute('data-video-id')
+  this.playerContainerEl = this.jumbotronEl.querySelector('.inline-video-player');
+  this.playerId = 'video-player-' + Math.random().toString(36).substr(2, 10);
+  this.playerEl = document.createElement('div');
+  this.playerEl.setAttribute('id', this.playerId);
+  this.playerContainerEl.appendChild(this.playerEl);
+
+  this.playerOptions = {
+    autoplay: 1,
+    controls: 1,
+    playsinline: 0,
+    modestbranding: 1,
+    showinfo: 0
+  };
+
+  this.closeButton = document.createElement('a');
+  this.closeButton.classList.add('close-video');
+  this.closeButton.innerHTML = '\
+    <svg class="icon icon-2" viewBox="0 0 256 256"\>\
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#close"></use\>\
+    </svg\>';
+
+  this.playerContainerEl.insertBefore(this.closeButton, this.playerContainerEl.firstChild);
+
+  this.bindEvents();
+};
+
+CRDS.JumbotronInlineVideoPlayer.prototype.initVideo = function() {
+  var _this = this;
+  this.player = new YT.Player(this.playerId, {
+    videoId: this.videoId,
+    playerVars: this.playerOptions,
+    events: {
+      onReady: function(event) {
+        _this.playVideo(event);
+      },
+      onStateChange: function(event) {
+        _this.onStateChange(event);
+      }
+    }
+  });
+  return true;
+};
+
+CRDS.JumbotronInlineVideoPlayer.prototype.bindEvents = function() {
   var _this = this;
 
-  window.addEventListener('resize', function(event) {
-    _this.resizePlayer();
+  this.videoTrigger.addEventListener('click', function(event) {
+    event.preventDefault();
+    _this.playVideo();
+  }, true);
+
+  this.closeButton.addEventListener('click', function(event) {
+    event.preventDefault();
+    _this.stopVideo();
   }, true);
 };
+
+CRDS.JumbotronInlineVideoPlayer.prototype.playVideo = function(event = null) {
+  if (!this.player) {
+    this.initVideo();
+    return true;
+  }
+  this.playerContainerEl.classList.add('active');
+};
+
+CRDS.JumbotronInlineVideoPlayer.prototype.stopVideo = function() {
+  this.playerContainerEl.classList.remove('active');
+  this.player.stopVideo();
+};
+
+CRDS.JumbotronInlineVideoPlayer.prototype.onStateChange = function(event) {
+  if (event.data == YT.PlayerState.ENDED) {
+    this.stopVideo();
+  }
+};
+

--- a/src/examples/jumbotron-bg-video/index.html
+++ b/src/examples/jumbotron-bg-video/index.html
@@ -11,8 +11,11 @@
   </head>
   <body>
 
-    <div class="jumbotron bg-video jumbotron-xl" data-video-id="LIdCR2rywl4">
-      <div class="bg-video-player"></div>
+    <div class="jumbotron bg-video jumbotron-xl" data-aspect-ratio="2.34615">
+      <div class="bg-video-player">
+        <video height="240" width="360" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted playsinline src="https://s3.amazonaws.com/crds-cms-uploads/media/video/loop-video.mp4">
+        </video>
+      </div>
       <div class="jumbotron-content">
         <h1 class="title">the main heading</h1>
         <p>


### PR DESCRIPTION
Work that was completed in US9042 involved changing the video
implementation from YouTube iFrame API to native HTML video tag. This
work updates documentation / examples in the DDK to allow users to
reference Jumbotron Background Video implementation for use around other
parts of the website.