### PR TITLE
DE4582 - DDK logo

### DIFF
--- a/src/app/assets/logos/logos.component.html
+++ b/src/app/assets/logos/logos.component.html
@@ -25,6 +25,25 @@
       </a>
     </div>
 
+    <h3 class="component-header">Crossroads Word Mark (Expanded)</h3>
+
+    <ddk-example>
+<svg class="icon icon-3" width="308px" height="81px" viewBox="0 0 308 81">
+  <use xlink:href="assets/svgs/crossroads-church-logo.svg#crossroads-church-logo"></use>
+</svg>
+    </ddk-example>
+
+    <div class="link-group-download push-half-top">
+      <a class="link-download" href="assets/svgs/crossroads-church-logo.svg#crossroads-church-logo" download>
+        <span>
+          <svg class="icon icon-1" viewBox="0 0 256 256">
+            <use xlink:href="/assets/svgs/icons.svg#download"></use>
+          </svg>
+        </span>
+        <span>Download Crossroads word mark (SVG)</span>
+      </a>
+    </div>
+
     <h3 class="component-header">Screwhead Logo</h3>
 
     <ddk-example>


### PR DESCRIPTION
Add expanded CR logo to logo section of DDK.

Testable on `/assets/logos` and `/designers/guidelines/logos`

Corresponding PR: crdschurch/crds-styles#243