### PR TITLE
Feature/us10588 disabled readonly form controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cheerio": "^1.0.0-rc.2",
     "clipboard": "^1.7.1",
     "core-js": "^2.4.1",
-    "crds-styles": "1.1.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.4",
     "ng2-bootstrap": "~1.3.2",

--- a/src/app/ui-components/atoms/forms/form-states/form-states.component.html
+++ b/src/app/ui-components/atoms/forms/form-states/form-states.component.html
@@ -58,7 +58,7 @@
 </ddk-example>
 
 <h3 class="component-header">Input Field &mdash; Disabled</h3>
-<p>Disabled inputs prevent users interactions and appear lighter in color and add a <code>not-allowed</code> cursor.</p>
+<p>Disabled inputs prevent user interactions and appear lighter in color and add a <code>not-allowed</code> cursor.</p>
 <ddk-example>
 <div class="form-group">
   <label for="email" class="sr-only">Email</label>

--- a/src/app/ui-components/atoms/forms/form-states/form-states.component.html
+++ b/src/app/ui-components/atoms/forms/form-states/form-states.component.html
@@ -58,10 +58,19 @@
 </ddk-example>
 
 <h3 class="component-header">Input Field &mdash; Disabled</h3>
-<p>Disabled inputs appear lighter in color and adds a <code>not-allowed</code> cursor.</p>
+<p>Disabled inputs prevent users interactions and appear lighter in color and add a <code>not-allowed</code> cursor.</p>
 <ddk-example>
 <div class="form-group">
   <label for="email" class="sr-only">Email</label>
-  <input type="email" disabled name="email" value="" placeholder="Email" class="form-control">
+  <input type="email" name="email" value="" placeholder="Email" class="form-control" disabled>
+</div>
+</ddk-example>
+
+<h3 class="component-header">Input Field &mdash; Read-only</h3>
+<p>Read-only inputs prevent modification of the input's value. Read-only inputs appear lighter, but keep the standard cursor.</p>
+<ddk-example>
+<div class="form-group">
+  <label for="email" class="sr-only">Email</label>
+  <input type="email" name="email" value="" placeholder="Email" class="form-control" readonly>
 </div>
 </ddk-example>

--- a/src/app/ui-components/atoms/forms/form-states/form-states.component.html
+++ b/src/app/ui-components/atoms/forms/form-states/form-states.component.html
@@ -56,3 +56,12 @@
   <p class="help-block">Separate additional addresses with a comma</p>
 </div>
 </ddk-example>
+
+<h3 class="component-header">Input Field &mdash; Disabled</h3>
+<p>Disabled inputs appear lighter in color and adds a <code>not-allowed</code> cursor.</p>
+<ddk-example>
+<div class="form-group">
+  <label for="email" class="sr-only">Email</label>
+  <input type="email" disabled name="email" value="" placeholder="Email" class="form-control">
+</div>
+</ddk-example>


### PR DESCRIPTION
Given a user
When viewing any form element marked as disabled or readonly
Then I should see a clear distinction from other active elements:

Disabled inputs prevent user interactions and appear lighter in color and add a not-allowed cursor.
Read-only inputs appear lighter, but keep the standard cursor

Given a user
When viewing the form states page in the DDK
Then I should see representations for input fields in disabled and read-only states.

Linked with https://github.com/crdschurch/crds-styles/pull/246