### PR TITLE
DE4830 - Dark Theme Interactive Examples

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -9,6 +9,7 @@ import { AppComponent } from './app.component';
 import { HeaderComponent } from './layout/header/header.component';
 import { FooterComponent } from './layout/footer/footer.component';
 import { ThemeToggleSwitchComponent } from './directives/theme-toggle-switch/theme-toggle-switch.component';
+import { ThemeToggleSwitchService } from './directives/theme-toggle-switch/theme-toggle-switch.service';
 import { ContentBlockModule } from 'crds-ng2-content-block';
 
 import { SearchComponent } from './shared/search/search.component';
@@ -33,7 +34,8 @@ describe('App: CrdsDdk', () => {
       ],
       providers: [
         SearchService,
-        LinkableHeaderService
+        LinkableHeaderService,
+        ThemeToggleSwitchService
       ]
     });
   });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { CollapseModule } from 'ng2-bootstrap';
 import { BootstrapDropdownDirective } from './directives/bootstrap-dropdown/bootstrap-dropdown.directive';
 import { BootstrapDropdownService } from './directives/bootstrap-dropdown/bootstrap-dropdown.service';
 import { ThemeToggleSwitchComponent } from './directives/theme-toggle-switch/theme-toggle-switch.component';
+import { ThemeToggleSwitchService } from './directives/theme-toggle-switch/theme-toggle-switch.service';
 import { ContentBlockModule } from 'crds-ng2-content-block';
 import { ScrollToModule } from 'ng2-scroll-to';
 
@@ -62,7 +63,8 @@ import { DashboardComponent } from './dashboard/dashboard.component';
   providers: [
     BootstrapDropdownService,
     LinkableHeaderService,
-    SearchService
+    SearchService,
+    ThemeToggleSwitchService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/directives/theme-toggle-switch/theme-toggle-switch.component.ts
+++ b/src/app/directives/theme-toggle-switch/theme-toggle-switch.component.ts
@@ -13,7 +13,6 @@ import { ThemeToggleSwitchService } from './theme-toggle-switch.service';
 export class ThemeToggleSwitchComponent {
 
   private body;
-  private state: String = 'off';
   private selector: String = 'dark-theme';
 
   @Output() stateChange = new EventEmitter<any>();
@@ -23,19 +22,15 @@ export class ThemeToggleSwitchComponent {
   }
 
   onSwitch() {
-    this.state = this.state === 'on' ? 'off' : 'on';
-    this.stateChange.emit({
-      value: this.state
-    });
+    this.toggleSwitchService.toggleState();
     this.toggleClass();
   }
 
   toggleClass() {
-    if (this.state === 'on') {
+    if (this.toggleSwitchService.currentState === 'on') {
       this.body.classList.add(this.selector);
     } else {
       this.body.classList.remove(this.selector);
     }
-    this.toggleSwitchService.toggleState(this.state);
   }
 }

--- a/src/app/directives/theme-toggle-switch/theme-toggle-switch.component.ts
+++ b/src/app/directives/theme-toggle-switch/theme-toggle-switch.component.ts
@@ -1,4 +1,6 @@
-import { Component, EventEmitter, Input, Output  } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { ThemeToggleSwitchService } from './theme-toggle-switch.service';
 
 @Component({
   selector: 'theme-toggle-switch',
@@ -16,7 +18,7 @@ export class ThemeToggleSwitchComponent {
 
   @Output() stateChange = new EventEmitter<any>();
 
-  constructor() {
+  constructor(private toggleSwitchService: ThemeToggleSwitchService) {
     this.body = document.getElementsByTagName('body')[0];
   }
 
@@ -34,5 +36,6 @@ export class ThemeToggleSwitchComponent {
     } else {
       this.body.classList.remove(this.selector);
     }
+    this.toggleSwitchService.toggleState(this.state);
   }
 }

--- a/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
+++ b/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
@@ -6,11 +6,13 @@ import { Subject } from 'rxjs/Subject';
 export class ThemeToggleSwitchService {
 
   public currentState: String = 'off';
+  public themeClass: String = 'light-theme';
 
   private state = new Subject<any>();
 
   toggleState() {
     this.currentState = this.currentState === 'on' ? 'off' : 'on';
+    this.themeClass = this.currentState === 'on' ? 'dark-theme' : 'light-theme';
     this.state.next(this.currentState);
   }
 

--- a/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
+++ b/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
@@ -5,10 +5,13 @@ import { Subject } from 'rxjs/Subject';
 @Injectable()
 export class ThemeToggleSwitchService {
 
+  public currentState: String = 'off';
+
   private state = new Subject<any>();
 
-  toggleState(value: String) {
-    this.state.next(value);
+  toggleState() {
+    this.currentState = this.currentState === 'on' ? 'off' : 'on';
+    this.state.next(this.currentState);
   }
 
   getState(): Observable<any> {

--- a/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
+++ b/src/app/directives/theme-toggle-switch/theme-toggle-switch.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Subject } from 'rxjs/Subject';
+
+@Injectable()
+export class ThemeToggleSwitchService {
+
+  private state = new Subject<any>();
+
+  toggleState(value: String) {
+    this.state.next(value);
+  }
+
+  getState(): Observable<any> {
+    return this.state.asObservable();
+  }
+}

--- a/src/app/layout/header/header.component.spec.ts
+++ b/src/app/layout/header/header.component.spec.ts
@@ -6,6 +6,7 @@ import { HttpModule } from '@angular/http';
 
 import { HeaderComponent } from './header.component';
 import { ThemeToggleSwitchComponent } from '../../directives/theme-toggle-switch/theme-toggle-switch.component';
+import { ThemeToggleSwitchService } from '../../directives/theme-toggle-switch/theme-toggle-switch.service';
 import { SearchComponent } from '../../shared/search/search.component';
 import { SearchService } from '../../shared/search/search.service';
 import { CollapseModule } from 'ng2-bootstrap';
@@ -24,7 +25,8 @@ describe('Component: Header', () => {
         HttpModule
       ],
       providers: [
-        SearchService
+        SearchService,
+        ThemeToggleSwitchService
       ]
     });
   });

--- a/src/app/shared/example/example.component.html
+++ b/src/app/shared/example/example.component.html
@@ -7,7 +7,7 @@
 </button>
 
 <div class="crds-example crds-embedded-markup" [hidden]="markupInline">
-  <iframe [id]="iframeId" [src]="iframeSrc" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true"></iframe>
+  <iframe #iframe [src]="iframeSrc" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true" (load)="iframeLoaded()"></iframe>
   <div class="example-row">
     <div class="tree">
       <div class="list-group">

--- a/src/app/shared/example/example.component.html
+++ b/src/app/shared/example/example.component.html
@@ -7,7 +7,7 @@
 </button>
 
 <div class="crds-example crds-embedded-markup" [hidden]="markupInline">
-  <iframe #iframe [src]="iframeSrc" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true" (load)="iframeLoaded()"></iframe>
+  <iframe #iframe [src]="iframeSrc" [hidden]="iframeHidden" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true" (load)="iframeLoaded()"></iframe>
   <div class="example-row">
     <div class="tree">
       <div class="list-group">

--- a/src/app/shared/example/example.component.html
+++ b/src/app/shared/example/example.component.html
@@ -7,7 +7,7 @@
 </button>
 
 <div class="crds-example crds-embedded-markup" [hidden]="markupInline">
-  <iframe [src]="iframeSrc" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true"></iframe>
+  <iframe [id]="iframeId" [src]="iframeSrc" *ngIf="iframeSrc !== undefined" width="{{width}}" height="{{height}}" frameborder="0" allowTransparency="true"></iframe>
   <div class="example-row">
     <div class="tree">
       <div class="list-group">

--- a/src/app/shared/example/example.component.spec.ts
+++ b/src/app/shared/example/example.component.spec.ts
@@ -4,6 +4,8 @@ import { ExampleComponent } from './example.component';
 
 import { ToastsManager } from 'ng2-toastr/ng2-toastr';
 
+import { ThemeToggleSwitchService } from '../../directives/theme-toggle-switch/theme-toggle-switch.service';
+
 let mockToast;
 
 describe('Component: ExampleComponent', () => {
@@ -18,7 +20,8 @@ describe('Component: ExampleComponent', () => {
         ExampleComponent
       ],
       providers: [
-        { provide: ToastsManager, useValue: mockToast }
+        { provide: ToastsManager, useValue: mockToast },
+        ThemeToggleSwitchService
       ]
     });
     this.fixture = TestBed.createComponent(ExampleComponent);

--- a/src/app/shared/example/example.component.ts
+++ b/src/app/shared/example/example.component.ts
@@ -23,7 +23,6 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
   public clippableUUID: string;
   public clippableHTML: string;
   public clippableMoved = false;
-  public iframeId: string;
 
   private el: Element;
   private iframeSrc: SafeResourceUrl;
@@ -41,6 +40,7 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
   @Input() width = '100%';
   @Input() height = '100';
   @ViewChild('contentRef') contentRef;
+  @ViewChild('iframe') iframe;
 
   constructor(private sanitizer: DomSanitizer,
               private http: Http,
@@ -58,15 +58,9 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
       this.markup = '<html></html>';
       this.http.get(`${this.path}manifest.json`).subscribe(this.parseManifest.bind(this));
     }
-    this.iframeId = `iframe-example-${uuidv4()}`;
 
     this.toggleSwitchService.getState().subscribe(state => {
-      const iframe = document.getElementById(this.iframeId)
-      if (iframe) {
-        const iframeWindow = iframe['contentWindow'];
-        const themeClass = state === 'on' ? 'dark-theme' : 'light-theme';
-        iframeWindow.postMessage(themeClass, '*');
-      }
+      this.matchTheme();
     });
   }
 
@@ -85,6 +79,12 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
         this.preformattedMarkup = pre.innerHTML;
         pre.remove();
       }
+    }
+  }
+
+  iframeLoaded() {
+    if (this.iframe) {
+      this.matchTheme();
     }
   }
 
@@ -196,5 +196,13 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
     }
     el.appendChild(clippable);
     this.clippableMoved = true;
+  }
+
+  private matchTheme() {
+    if (this.iframe) {
+      const iframeWindow = this.iframe.nativeElement['contentWindow'];
+      const themeClass = this.toggleSwitchService.currentState === 'on' ? 'dark-theme' : 'light-theme';
+      iframeWindow.postMessage(themeClass, '*');
+    }
   }
 }

--- a/src/app/shared/example/example.component.ts
+++ b/src/app/shared/example/example.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnInit, AfterViewInit, AfterViewChecked, ElementRef, 
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Http, Response } from '@angular/http';
 
+import { ThemeToggleSwitchService } from '../../directives/theme-toggle-switch/theme-toggle-switch.service';
+
 let Prism = require('prismjs');
 let path = require('path');
 let entities = new (require('html-entities').Html5Entities)();
@@ -21,6 +23,7 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
   public clippableUUID: string;
   public clippableHTML: string;
   public clippableMoved = false;
+  public iframeId: string;
 
   private el: Element;
   private iframeSrc: SafeResourceUrl;
@@ -43,7 +46,8 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
               private http: Http,
               private elementRef: ElementRef,
               private toastr: ToastsManager,
-              private vRef: ViewContainerRef) {
+              private vRef: ViewContainerRef,
+              private toggleSwitchService: ThemeToggleSwitchService) {
     this.el = <Element>this.elementRef.nativeElement;
     this.toastr.setRootViewContainerRef(vRef);
   }
@@ -54,6 +58,16 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
       this.markup = '<html></html>';
       this.http.get(`${this.path}manifest.json`).subscribe(this.parseManifest.bind(this));
     }
+    this.iframeId = `iframe-example-${uuidv4()}`;
+
+    this.toggleSwitchService.getState().subscribe(state => {
+      const iframe = document.getElementById(this.iframeId)
+      if (iframe) {
+        const iframeWindow = iframe['contentWindow'];
+        const themeClass = state === 'on' ? 'dark-theme' : 'light-theme';
+        iframeWindow.postMessage(themeClass, '*');
+      }
+    });
   }
 
   ngAfterViewChecked() {

--- a/src/app/shared/example/example.component.ts
+++ b/src/app/shared/example/example.component.ts
@@ -26,6 +26,7 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
 
   private el: Element;
   private iframeSrc: SafeResourceUrl;
+  private iframeHidden = true;
   private manifest: any;
   private rootPath = '/examples/';
   private path: string;
@@ -85,6 +86,13 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
   iframeLoaded() {
     if (this.iframe) {
       this.matchTheme();
+
+      // The toggle has an animation attached to it, so if the dark theme is
+      // active, there will be a flash of white background. So we delay until
+      // the animation has had time to complete.
+      setTimeout(() => {
+        this.iframeHidden = false;
+      }, 250);
     }
   }
 
@@ -199,10 +207,9 @@ export class ExampleComponent implements OnInit, AfterViewInit, AfterViewChecked
   }
 
   private matchTheme() {
-    if (this.iframe) {
-      const iframeWindow = this.iframe.nativeElement['contentWindow'];
-      const themeClass = this.toggleSwitchService.currentState === 'on' ? 'dark-theme' : 'light-theme';
-      iframeWindow.postMessage(themeClass, '*');
-    }
+    if (!this.iframe) { return; }
+    const iframeWindow = this.iframe.nativeElement['contentWindow'];
+    if (!iframeWindow) { return; }
+    iframeWindow.postMessage(this.toggleSwitchService.themeClass, '*');
   }
 }

--- a/src/app/ui-components/atoms/icons/inline-svg/inline-svg.component.spec.ts
+++ b/src/app/ui-components/atoms/icons/inline-svg/inline-svg.component.spec.ts
@@ -5,6 +5,8 @@ import { IconService } from '../../../../directives/icons/icons.service';
 import { HttpModule } from '@angular/http';
 import { ExampleModule } from '../../../../shared/example/example.module';
 
+import { ThemeToggleSwitchService } from '../../../../directives/theme-toggle-switch/theme-toggle-switch.service';
+
 describe('Component: IconInline', () => {
 
   beforeEach(() => {
@@ -17,7 +19,8 @@ describe('Component: IconInline', () => {
         IconInlineComponent
       ],
       providers: [
-        IconService
+        IconService,
+        ThemeToggleSwitchService
       ]
     });
     this.fixture = TestBed.createComponent(IconInlineComponent);

--- a/src/app/ui-components/core/colors/backgrounds/backgrounds.component.spec.ts
+++ b/src/app/ui-components/core/colors/backgrounds/backgrounds.component.spec.ts
@@ -3,6 +3,8 @@ import { ColorBackgroundsComponent } from './backgrounds.component';
 import { ExampleModule } from '../../../../shared/example/example.module';
 import { HttpModule } from '@angular/http';
 
+import { ThemeToggleSwitchService } from '../../../../directives/theme-toggle-switch/theme-toggle-switch.service';
+
 describe('Component: ColorBackgroundsComponent', () => {
 
   let component;
@@ -11,7 +13,8 @@ describe('Component: ColorBackgroundsComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ExampleModule, HttpModule],
-      declarations: [ColorBackgroundsComponent]
+      declarations: [ColorBackgroundsComponent],
+      providers: [ThemeToggleSwitchService]
     });
     this.fixture = TestBed.createComponent(ColorBackgroundsComponent);
     this.component = this.fixture.componentInstance;

--- a/src/app/ui-components/core/colors/text/text.component.spec.ts
+++ b/src/app/ui-components/core/colors/text/text.component.spec.ts
@@ -3,6 +3,8 @@ import { ColorTextComponent } from './text.component';
 import { ExampleModule } from '../../../../shared/example/example.module';
 import { HttpModule } from '@angular/http';
 
+import { ThemeToggleSwitchService } from '../../../../directives/theme-toggle-switch/theme-toggle-switch.service';
+
 describe('Component: ColorTextComponent', () => {
 
   let component;
@@ -11,7 +13,8 @@ describe('Component: ColorTextComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ExampleModule, HttpModule],
-      declarations: [ColorTextComponent]
+      declarations: [ColorTextComponent],
+      providers: [ThemeToggleSwitchService]
     });
     this.fixture = TestBed.createComponent(ColorTextComponent);
     this.component = this.fixture.componentInstance;

--- a/src/examples/_shared/theme_toggler.js
+++ b/src/examples/_shared/theme_toggler.js
@@ -1,0 +1,5 @@
+window.addEventListener('message', function(event) {
+  if (event.origin === window.location.origin) {
+    document.body.classList = event.data;
+  }
+}, false);

--- a/src/examples/accordion/index.html
+++ b/src/examples/accordion/index.html
@@ -1,63 +1,82 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap accordion</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>NGX-Bootstrap Accordion</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
-    System.import('app')
-      .catch(console.error.bind(console));
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+
+  <script>
+    System.import('app').catch(console.error.bind(console));
+
   </script>
+
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+
+</head>
+
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/button-dropdown/index.html
+++ b/src/examples/button-dropdown/index.html
@@ -1,63 +1,79 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap datepicker</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>NGX-Bootstrap Button Dropdown</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/card-deck-carousel/index.html
+++ b/src/examples/card-deck-carousel/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>flickity card carousel</title>
+  <title>Card Deck - Carousel</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" id="viewport-meta" />
 
   <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
@@ -17,6 +17,8 @@
     } catch (e) {}
 
   </script>
+
+  <script src="/examples/_shared/theme_toggler.js"></script>
 </head>
 
 <body>
@@ -154,8 +156,10 @@
     (function () {
       new CRDS.CardCarousels()
     })();
+
   </script>
 
 </body>
 
 </html>
+

--- a/src/examples/card-deck-default/index.html
+++ b/src/examples/card-deck-default/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>flickity card carousel</title>
+  <title>Card Deck - Default</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" id="viewport-meta" />
 
   <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
@@ -17,6 +17,8 @@
     } catch (e) {}
 
   </script>
+
+  <script src="/examples/_shared/theme_toggler.js"></script>
 </head>
 
 <body>

--- a/src/examples/charts/index.html
+++ b/src/examples/charts/index.html
@@ -1,67 +1,83 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>SVG Chart Example</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>SVG Chart Example</title>
 
-    <script src="//unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="//unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="//unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="//unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
+  <link rel="stylesheet" href="/app.css" />
 
-    <script src="//cdn.jsdelivr.net/npm/svg.js@2.6.3/dist/svg.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/svg.pathmorphing.js@0.1.1/dist/svg.pathmorphing.min.js"></script>
+  <script src="//unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="//unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="//unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="//unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
 
-    <script>
+  <script src="//cdn.jsdelivr.net/npm/svg.js@2.6.3/dist/svg.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/svg.pathmorphing.js@0.1.1/dist/svg.pathmorphing.min.js"></script>
+
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/datepicker/index.html
+++ b/src/examples/datepicker/index.html
@@ -1,63 +1,79 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap datepicker</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>NGX-Bootstrap Datepicker</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/jumbotron-bg-video/index.html
+++ b/src/examples/jumbotron-bg-video/index.html
@@ -1,40 +1,53 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Jumbotron Video</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <title>Jumbotron Video</title>
 
-    <script src="https://use.typekit.net/ccb3vpa.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
-  <body>
+  <link rel="stylesheet" href="/app.css" />
 
-    <div class="jumbotron bg-video jumbotron-xl" data-aspect-ratio="2.34615">
-      <div class="bg-video-player">
-        <video height="240" width="360" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted playsinline src="https://s3.amazonaws.com/crds-cms-uploads/media/video/loop-video.mp4">
-        </video>
-      </div>
-      <div class="jumbotron-content">
-        <h1 class="title">the main heading</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Repudiandae quos reiciendis vitae eum.
-        </p>
-        <p class="text-center">
-          <a class="btn btn-primary" href="#">Primary CTA</a>
-          <a class="btn btn-gray" href="#">Secondary CTA</a>
-        </p>
-      </div>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
+
+  </script>
+
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
+
+<body>
+
+  <div class="jumbotron bg-video jumbotron-xl" data-aspect-ratio="2.34615">
+    <div class="bg-video-player">
+      <video height="240" width="360" class="bg-jumbotron-video hide" autoplay="autoplay" loop="loop" muted playsinline src="https://s3.amazonaws.com/crds-cms-uploads/media/video/loop-video.mp4">
+      </video>
     </div>
+    <div class="jumbotron-content">
+      <h1 class="title">the main heading</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repudiandae quos reiciendis vitae eum.
+      </p>
+      <p class="text-center">
+        <a class="btn btn-primary" href="#">Primary CTA</a>
+        <a class="btn btn-gray" href="#">Secondary CTA</a>
+      </p>
+    </div>
+  </div>
 
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.1.0.min.js"></script>
+  <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.1.0.min.js"></script>
 
-    <script>
-      (function () {
-        new CRDS.JumbotronVideos();
-      })();
-    </script>
+  <script>
+    (function () {
+      new CRDS.JumbotronVideos();
+    })();
 
-  </body>
+  </script>
+
+</body>
+
 </html>
+

--- a/src/examples/jumbotron-inline-video/index.html
+++ b/src/examples/jumbotron-inline-video/index.html
@@ -1,39 +1,52 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Jumbotron Video</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <title>Jumbotron Video</title>
 
-    <script src="/examples/jumbotron-inline-video/inline-video.js"></script>
-    <script src="https://use.typekit.net/ccb3vpa.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
-  <body>
+  <link rel="stylesheet" href="/app.css" />
 
-    <div class="jumbotron inline-video jumbotron-xl" style="background-image: url('//crds-cms-uploads.imgix.net/media/stills/crossroads-church-home.jpg');">
-      <div class="inline-video-player"></div>
-      <div class="jumbotron-content">
-        <a href="#" class="inline-video-trigger" data-video-id="LIdCR2rywl4"></a>
-        <h1 class="title">the main heading</h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Repudiandae quos reiciendis vitae eum.
-        </p>
-        <p class="text-center">
-          <a class="btn btn-primary" href="#">Primary CTA</a>
-          <a class="btn btn-gray" href="#">Secondary CTA</a>
-        </p>
-      </div>
+  <script src="/examples/jumbotron-inline-video/inline-video.js"></script>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
+
+  </script>
+
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
+
+<body>
+
+  <div class="jumbotron inline-video jumbotron-xl" style="background-image: url('//crds-cms-uploads.imgix.net/media/stills/crossroads-church-home.jpg');">
+    <div class="inline-video-player"></div>
+    <div class="jumbotron-content">
+      <a href="#" class="inline-video-trigger" data-video-id="LIdCR2rywl4"></a>
+      <h1 class="title">the main heading</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repudiandae quos reiciendis vitae eum.
+      </p>
+      <p class="text-center">
+        <a class="btn btn-primary" href="#">Primary CTA</a>
+        <a class="btn btn-gray" href="#">Secondary CTA</a>
+      </p>
     </div>
+  </div>
 
-    <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.1.0.min.js"></script>
+  <script src="//d1tmclqz61gqwd.cloudfront.net/javascripts/crds-jumbotron-video-v0.1.0.min.js"></script>
 
-    <script>
-      (function () {
-        new CRDS.JumbotronVideos();
-      })();
-    </script>
+  <script>
+    (function () {
+      new CRDS.JumbotronVideos();
+    })();
 
-  </body>
+  </script>
+
+</body>
+
 </html>
+

--- a/src/examples/map/index.html
+++ b/src/examples/map/index.html
@@ -1,64 +1,80 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>angular2-google-maps</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>angular2-google-maps</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <app-root data-iframe-height>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <app-root data-iframe-height>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </app-root>
+        </g>
+      </svg>
+    </div>
+  </app-root>
 
-  </body>
+</body>
+
 </html>
+

--- a/src/examples/timepicker/index.html
+++ b/src/examples/timepicker/index.html
@@ -1,63 +1,79 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap datepicker</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>ng2-bootstrap datepicker</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/toastr/index.html
+++ b/src/examples/toastr/index.html
@@ -1,66 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ngx-toastr</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>ngx-toastr</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 32px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  </script>
 
-    <div class="panel panel-default">
-      <br><br><br>
-      <app-root>
-        <div class="preloader-wrapper">
-          <svg viewBox="0 0 102 101" class="preloader">
-            <g fill="none" fill-rule="evenodd">
-              <g transform="translate(1 1)" stroke-width="2">
-                <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-                <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-              </g>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
+
+<body>
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 32px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <div class="panel panel-default">
+    <br>
+    <br>
+    <br>
+    <app-root>
+      <div class="preloader-wrapper">
+        <svg viewBox="0 0 102 101" class="preloader">
+          <g fill="none" fill-rule="evenodd">
+            <g transform="translate(1 1)" stroke-width="2">
+              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
             </g>
-          </svg>
-        </div>
-      </app-root>
-      <br><br><br>
-    </div>
-  </body>
+          </g>
+        </svg>
+      </div>
+    </app-root>
+    <br>
+    <br>
+    <br>
+  </div>
+</body>
+
 </html>
+

--- a/src/examples/tooltips/index.html
+++ b/src/examples/tooltips/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <base href="." />
-  <title>ng2-bootstrap accordion</title>
+  <title>NGX-Bootstrap Tooltips</title>
 
   <link rel="stylesheet" href="/app.css" />
 

--- a/src/examples/tooltips/index.html
+++ b/src/examples/tooltips/index.html
@@ -1,63 +1,79 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap accordion</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>ng2-bootstrap accordion</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
-      @keyframes rotateInitLoadingSpinner {
-        100% {
-          transform:rotate(360deg);
-        }
-      }
-      .preloader {
-        position: absolute;
-        display: block;
-        top: 48px;
-        left: calc(50% - 37.5px);
-        width: 75px;
-        height: 75px;
-        margin: 0 auto;
-        background: transparent;
-        animation: rotateInitLoadingSpinner 700ms linear infinite;
-      }
-      .preloader-wrapper {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      }
-    </style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
 
-    <my-app>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+<body>
+
+  <style>
+    @keyframes rotateInitLoadingSpinner {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    .preloader {
+      position: absolute;
+      display: block;
+      top: 48px;
+      left: calc(50% - 37.5px);
+      width: 75px;
+      height: 75px;
+      margin: 0 auto;
+      background: transparent;
+      animation: rotateInitLoadingSpinner 700ms linear infinite;
+    }
+
+    .preloader-wrapper {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+  </style>
+
+  <my-app>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </my-app>
-  </body>
+        </g>
+      </svg>
+    </div>
+  </my-app>
+</body>
+
 </html>
+

--- a/src/examples/video-modals/index.html
+++ b/src/examples/video-modals/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <base href="." />
-  <title>ng2-bootstrap datepicker</title>
+  <title>Video Modals</title>
 
   <link rel="stylesheet" href="/app.css" />
 

--- a/src/examples/video-modals/index.html
+++ b/src/examples/video-modals/index.html
@@ -1,32 +1,44 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <base href="." />
-    <title>ng2-bootstrap datepicker</title>
 
-    <link rel="stylesheet" href="/app.css" />
+<head>
+  <base href="." />
+  <title>ng2-bootstrap datepicker</title>
 
-    <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
-    <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
-    <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
-    <script src="config.js"></script>
-    <script>
+  <link rel="stylesheet" href="/app.css" />
+
+  <script src="https://unpkg.com/zone.js/dist/zone.js"></script>
+  <script src="https://unpkg.com/zone.js/dist/long-stack-trace-zone.js"></script>
+  <script src="https://unpkg.com/reflect-metadata@0.1.3/Reflect.js"></script>
+  <script src="https://unpkg.com/systemjs@0.19.31/dist/system.js"></script>
+  <script src="config.js"></script>
+  <script>
     System.import('app')
       .catch(console.error.bind(console));
+
   </script>
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
-  <script>try{Typekit.load({ async: true });}catch(e){}</script>
-  </head>
+  <script>
+    try {
+      Typekit.load({
+        async: true
+      });
+    } catch (e) {}
 
-  <body>
+  </script>
 
-    <style>
+  <script src="/examples/_shared/theme_toggler.js"></script>
+</head>
+
+<body>
+
+  <style>
     @keyframes rotateInitLoadingSpinner {
       100% {
-        transform:rotate(360deg);
+        transform: rotate(360deg);
       }
     }
+
     .preloader {
       position: absolute;
       display: block;
@@ -38,6 +50,7 @@
       background: transparent;
       animation: rotateInitLoadingSpinner 700ms linear infinite;
     }
+
     .preloader-wrapper {
       position: absolute;
       top: 0;
@@ -45,20 +58,23 @@
       left: 0;
       right: 0;
     }
-    </style>
 
-    <app-root data-iframe-height>
-      <div class="preloader-wrapper">
-        <svg viewBox="0 0 102 101" class="preloader">
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
-              <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
-            </g>
+  </style>
+
+  <app-root data-iframe-height>
+    <div class="preloader-wrapper">
+      <svg viewBox="0 0 102 101" class="preloader">
+        <g fill="none" fill-rule="evenodd">
+          <g transform="translate(1 1)" stroke-width="2">
+            <ellipse stroke="#eee" cx="50" cy="49.421" rx="50" ry="49.421"></ellipse>
+            <path d="M50 98.842c27.614 0 50-22.127 50-49.42C100 22.125 77.614 0 50 0" stroke-opacity=".631" stroke="#3B6E8F"></path>
           </g>
-        </svg>
-      </div>
-    </app-root>
+        </g>
+      </svg>
+    </div>
+  </app-root>
 
-  </body>
+</body>
+
 </html>
+

--- a/src/styles/_examples.scss
+++ b/src/styles/_examples.scss
@@ -172,6 +172,9 @@ crds-example {
 }
 
 .dark-theme .crds-embedded-markup {
+  pre {
+    color: $example-default-color-dark-theme;
+  }
   .example-row {
     background-color: $example-bg-dark-theme;
     border-top-color: $example-border-color-dark-theme;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -8,6 +8,7 @@ $example-list-border-color: #ddd;
 $example-list-hover-bg: $gray;
 $example-bg-dark-theme: #272822;
 $example-border-color-dark-theme: #343434;
+$example-default-color-dark-theme: #f8f8f2;
 
 // Bootstrap overrides for DDK dark-theme
 $navbar-inverse-bg: $cr-black;


### PR DESCRIPTION
The primary focus of this defect was to support dark-theme toggling within interactive examples. I ended up finding a few other dark theme issues and fixed those along the way. All in all, in conjunction with crdschurch/crds-styles#271, this addresses:

- Style support for dark theme on accordions, panels, and striped tables
- Communicating the current theme to interactive examples and toggling to match
- Maintaining a dark theme within interactive examples when navigating to a new page