### PR TITLE
Remove inline CSS to enable mobile nav.

### DIFF
--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -26,7 +26,7 @@
       </a>
     </div>
 
-    <div class="collapse navbar-collapse" style="display: none;" aria-expanded="false" aria-hidden="true">
+    <div class="collapse navbar-collapse" aria-expanded="false" aria-hidden="true">
       <ul class="nav navbar-nav navbar-right ddk-navbar">
         <li class="on">
           <a aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" role="button">


### PR DESCRIPTION
### Problem
Mobile nav doesn't open/close.

### Solution
Remove inline CSS to enable open/close functionality.