### PR TITLE
Remove .on class and styles so active state matches PROD.

### DIFF
--- a/_assets/stylesheets/_global.scss
+++ b/_assets/stylesheets/_global.scss
@@ -71,19 +71,11 @@ $navbar-inverse-border: darken($cr-gray-dark, 10);
       fill: $cr-gray;
     }
 
-    .navbar-nav li.on > a {
-      color: $cr-cyan;
-    }
-
     .dark-theme & {
       @extend .navbar-inverse;
 
       .navbar-brand {
         fill: $cr-white;
-      }
-
-      .navbar-nav li.on > a {
-        color: $cr-cyan;
       }
     }
 

--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -26,9 +26,9 @@
       </a>
     </div>
 
-    <div class="collapse navbar-collapse" style="display: none;" aria-expanded="false" aria-hidden="true">
+    <div class="collapse navbar-collapse" aria-expanded="false" aria-hidden="true">
       <ul class="nav navbar-nav navbar-right ddk-navbar">
-        <li class="on">
+        <li>
           <a aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" role="button">
             For Designers
             <svg class="icon" viewBox="0 0 256 256">


### PR DESCRIPTION
### Problem
Nav link for Designers is always blue, whether active or not.

### Solution
Remove `.on` class and related styles. This feels like broken markup that got brought in from DDK-NG as the active states for nav are black, not blue. The `.on` class doesn't appear to do anything, as Bootstrap uses an `.open` class to determine active state.