### PR TITLE
DE6235 Fixes Active State on Content Admin Submenu

### DIFF
--- a/content-administrators/copy-voice.html
+++ b/content-administrators/copy-voice.html
@@ -22,13 +22,13 @@ title: Copy/Voice
       <nav class="nav">
         <ul class="list-unstyled">
           <li>
-            <a href="/content-administrators/copy-voice">Copy/Voice</a>
+            <a class="active" href="/content-administrators/copy-voice">Copy/Voice</a>
           </li>
           <li>
             <a href="/content-administrators/monetate-templates">Monetate Templates</a>
           </li>
           <li>
-            <a class="active" href="/content-administrators/markdown-primer">Markdown Primer</a>
+            <a href="/content-administrators/markdown-primer">Markdown Primer</a>
           </li>
         </ul>
       </nav>

--- a/content-administrators/monetate-templates.html
+++ b/content-administrators/monetate-templates.html
@@ -44,10 +44,10 @@ cta-3:
             <a href="/content-administrators/copy-voice">Copy/Voice</a>
           </li>
           <li>
-            <a href="/content-administrators/monetate-templates">Monetate Templates</a>
+            <a class="active" href="/content-administrators/monetate-templates">Monetate Templates</a>
           </li>
           <li>
-            <a class="active" href="/content-administrators/markdown-primer">Markdown Primer</a>
+            <a href="/content-administrators/markdown-primer">Markdown Primer</a>
           </li>
         </ul>
       </nav>
@@ -98,7 +98,7 @@ cta-3:
       </table>
 
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-1" fragment="voice" target="_self">
+        <a id="cta-1" name="cta-1" href="/content-administrators/monetate-templates#cta-1" fragment="cta-1" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>
@@ -126,12 +126,14 @@ cta-3:
       {% endexample %}
 
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-2" fragment="voice" target="_self">
+        <a id="cta-2" name="cta-2" href="/content-administrators/monetate-templates#cta-2" fragment="cta-2" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>
         </a>
-        <h2 class="component-header">CTA 2</h2>
+        <h2 class="component-header">
+          CTA 2
+        </h2>
       </div>
 
       {% example html %}
@@ -157,7 +159,7 @@ cta-3:
       {% endexample %}
 
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-3" fragment="voice" target="_self">
+        <a id="cta-3" name="cta-3" href="/content-administrators/monetate-templates#cta-3" fragment="cta-3" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>
@@ -191,7 +193,7 @@ cta-3:
         <p>Add <code>sm-pull-right</code> next to the Bootstrap classes (in our first example, the <code>&lt;div class="col-sm-4 col-md-3"&gt;</code>).</p>
       </div>
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-1-mini" fragment="voice" target="_self">
+        <a id="cta-1-mini" name="cta-1-mini" href="/content-administrators/monetate-templates#cta-1-mini" fragment="cta-1-mini" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>
@@ -226,7 +228,7 @@ cta-3:
       {% endexample %}
 
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-2-mini" fragment="voice" target="_self">
+        <a id="cta-2-mini" name="cta-2-mini" href="/content-administrators/monetate-templates#cta-2-mini" fragment="cta-2-mini" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>
@@ -255,7 +257,7 @@ cta-3:
       {% endexample %}
 
       <div class="linkable">
-        <a id="monetate" name="voice" href="/content-administrators/monetate-templates#cta-3-mini" fragment="voice" target="_self">
+        <a id="cta-3-mini" name="cta-3-mini" href="/content-administrators/monetate-templates#cta-3-mini" fragment="cta-3-mini" target="_self">
           <svg class="icon icon-1" viewBox="0 0 256 256">
             <use xmlns:xlink="//www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#link"></use>
           </svg>


### PR DESCRIPTION
Also fixes linkable sections on Monetate templates page

This page also is linked to the following crds-styles PR that was missed when the original story was merged:
https://github.com/crdschurch/crds-styles/pull/354
Because of submodules, the styles are reflected in Styleguide, but it won't be connected to the new version of crds-styles without being merged